### PR TITLE
Wdzl 37  feat/#2

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerCreateRequestDTO.java
@@ -1,0 +1,18 @@
+package com.prgrms.wadiz.domain.maker.dto.request;
+
+import com.prgrms.wadiz.domain.maker.entity.Maker;
+import lombok.Builder;
+
+@Builder
+public record MakerCreateRequestDTO(
+        String makerName,
+        String makerBrand,
+        String makerEmail) {
+    public Maker toEntity() {
+        return Maker.builder()
+                .makerName(makerName)
+                .makerBrand(makerBrand)
+                .makerEmail(makerEmail)
+                .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerModifyRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerModifyRequestDTO.java
@@ -1,0 +1,7 @@
+package com.prgrms.wadiz.domain.maker.dto.request;
+
+public record MakerModifyRequestDTO(
+        String makerName,
+        String makerBrand,
+        String makerEmail) {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/response/MakerResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/response/MakerResponseDTO.java
@@ -1,0 +1,17 @@
+package com.prgrms.wadiz.domain.maker.dto.response;
+
+import com.prgrms.wadiz.domain.maker.entity.Maker;
+import lombok.Builder;
+
+@Builder
+public record MakerResponseDTO(
+        String makerName,
+        String makerBrand,
+        String makerEmail) {
+    public Maker toEntity() {
+        return Maker.builder()
+                .makerName(makerName)
+                .makerEmail(makerEmail)
+                .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
@@ -1,10 +1,13 @@
 package com.prgrms.wadiz.domain.maker.entity;
 
+import com.prgrms.wadiz.domain.maker.dto.request.MakerCreateRequestDTO;
+import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
 import com.prgrms.wadiz.global.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
@@ -12,7 +15,8 @@ import javax.persistence.*;
 @Getter
 @Table(name = "makers")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Maker extends BaseEntity {
+@SQLDelete(sql = "UPDATE makers SET deleted = true WHERE maker_id = ?")
+public class Maker extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,15 +32,19 @@ public class Maker extends BaseEntity {
     @Column(nullable = false)
     private String makerEmail;
 
+    @Column(nullable = false)
+    private boolean deleted = Boolean.FALSE; // 삭제 여부 기본값 false
+
     @Builder
     public Maker(
             String makerName,
             String makerBrand,
-            String makerEmail
-    ) {
+            String makerEmail) {
+
         this.makerName = makerName;
         this.makerBrand = makerBrand;
         this.makerEmail = makerEmail;
+
     }
 
     public void changeMakerName(String makerName) {
@@ -49,5 +57,11 @@ public class Maker extends BaseEntity {
 
     public void changeMakerEmail(String makerEmail) {
         this.makerEmail = makerEmail;
+    }
+    public static MakerCreateRequestDTO toDTOForRequest(Maker maker) {
+        return new MakerCreateRequestDTO(maker.makerName, maker.makerBrand, maker.makerEmail);
+    }
+    public static MakerResponseDTO toDTOForResponse(Maker maker) {
+        return new MakerResponseDTO(maker.makerName, maker.makerBrand, maker.makerEmail);
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "makers")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE makers SET deleted = true WHERE maker_id = ?")
+@SQLDelete(sql = "UPDATE makers SET activated = false WHERE maker_id = ?")
 public class Maker extends BaseEntity{
 
     @Id
@@ -33,7 +33,7 @@ public class Maker extends BaseEntity{
     private String makerEmail;
 
     @Column(nullable = false)
-    private boolean deleted = Boolean.FALSE; // 삭제 여부 기본값 false
+    private boolean activated = Boolean.TRUE; // 활성화 여부 -> 삭제 시 FALSE
 
     @Builder
     public Maker(

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
@@ -1,0 +1,9 @@
+package com.prgrms.wadiz.domain.maker.repository;
+
+import com.prgrms.wadiz.domain.maker.entity.Maker;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MakerRepository extends JpaRepository<Maker, Long> {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
@@ -1,0 +1,51 @@
+package com.prgrms.wadiz.domain.maker.service;
+
+import com.prgrms.wadiz.domain.maker.dto.request.MakerCreateRequestDTO;
+import com.prgrms.wadiz.domain.maker.dto.request.MakerModifyRequestDTO;
+import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
+import com.prgrms.wadiz.domain.maker.entity.Maker;
+import com.prgrms.wadiz.domain.maker.repository.MakerRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MakerService {
+
+    private final MakerRepository makerRepository;
+
+    public MakerService(MakerRepository makerRepository) {
+        this.makerRepository = makerRepository;
+    }
+
+    @Transactional
+    public MakerResponseDTO signUpMaker(MakerCreateRequestDTO dto) {
+        Maker maker = makerRepository.save(dto.toEntity());
+        return Maker.toDTOForResponse(maker);
+    }
+
+    public MakerResponseDTO getMaker(Long id) {
+        Maker findMaker = makerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("id에 해당하는 Maker가 존재하지 않습니다."));
+        return Maker.toDTOForResponse(findMaker);
+    }
+
+    public MakerResponseDTO modifyMaker(
+            Long id,
+            MakerModifyRequestDTO dto
+    ) {
+
+        MakerResponseDTO makerDTO = getMaker(id);
+        Maker maker = makerDTO.toEntity();
+        maker.changeMakerName(dto.makerName());
+        maker.chaneMakerBrand(dto.makerBrand());
+        maker.changeMakerEmail(dto.makerEmail());
+
+        Maker save = makerRepository.save(maker);
+        return Maker.toDTOForResponse(save);
+    }
+
+    @Transactional
+    public void deleteMaker(Long id) {
+        makerRepository.deleteById(id);
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterCreateRequestDTO.java
@@ -1,0 +1,14 @@
+package com.prgrms.wadiz.domain.supporter.dto.request;
+
+import com.prgrms.wadiz.domain.supporter.entity.Supporter;
+import lombok.Builder;
+
+@Builder
+public record SupporterCreateRequestDTO(String name, String email) {
+    public Supporter toEntity() {
+        return Supporter.builder()
+                .name(name)
+                .email(email)
+                .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterUpdateRequestDTO.java
@@ -1,0 +1,4 @@
+package com.prgrms.wadiz.domain.supporter.dto.request;
+
+public record SupporterUpdateRequestDTO(String name, String email) {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/response/SupporterResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/response/SupporterResponseDTO.java
@@ -1,0 +1,15 @@
+package com.prgrms.wadiz.domain.supporter.dto.response;
+
+
+import com.prgrms.wadiz.domain.supporter.entity.Supporter;
+import lombok.Builder;
+
+@Builder
+public record SupporterResponseDTO(String name, String email) {
+    public Supporter toEntity() {
+        return Supporter.builder()
+                .name(name)
+                .email(email)
+                .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
@@ -1,21 +1,67 @@
 package com.prgrms.wadiz.domain.supporter.entity;
 
+import com.prgrms.wadiz.domain.supporter.dto.request.SupporterCreateRequestDTO;
+import com.prgrms.wadiz.domain.supporter.dto.response.SupporterResponseDTO;
 import com.prgrms.wadiz.global.BaseEntity;
-import lombok.Getter;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @Table(name = "supporters")
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE supporters SET deleted = true WHERE supporter_id = ?")
 public class Supporter extends BaseEntity {
     @Id
+    @Column(name="supporter_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long supporterId;
+    private Long id;
 
     @Column(nullable = false)
-    private String supporterName;
+    private String name;
 
     @Column(nullable = false)
-    private String supporterEmail;
+    private String email;
+
+    @Column(nullable = false)
+    private boolean deleted = Boolean.FALSE; // 삭제 여부 기본값 false
+
+    @Builder
+    public Supporter(
+            String name,
+            String email
+    ) {
+        this.name = name;
+        this.email = email;
+    }
+
+    @Builder
+    public Supporter(
+            String name,
+            String email,
+            Boolean isDeleted
+    ) {
+        this.name = name;
+        this.email = email;
+        this.deleted = isDeleted;
+    }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeEmail(String email) {
+        this.email = email;
+    }
+
+    public static SupporterCreateRequestDTO toDTOForRequest(Supporter supporter) {
+        return new SupporterCreateRequestDTO(supporter.getName(), supporter.getEmail());
+    }
+
+    public static SupporterResponseDTO toDTOForResponse(Supporter supporter) {
+        return new SupporterResponseDTO(supporter.getName(), supporter.getEmail());
+    }
+
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "supporters")
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE supporters SET deleted = true WHERE supporter_id = ?")
+@SQLDelete(sql = "UPDATE supporters SET activated = false WHERE supporter_id = ?")
 public class Supporter extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
@@ -15,53 +15,52 @@ import javax.persistence.*;
 @SQLDelete(sql = "UPDATE supporters SET deleted = true WHERE supporter_id = ?")
 public class Supporter extends BaseEntity {
     @Id
-    @Column(name="supporter_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long supporterId;
 
     @Column(nullable = false)
-    private String name;
+    private String supporterName;
 
     @Column(nullable = false)
-    private String email;
+    private String supporterEmail;
 
     @Column(nullable = false)
-    private boolean deleted = Boolean.FALSE; // 삭제 여부 기본값 false
+    private boolean activated = Boolean.TRUE; // 활성화 여부 -> 삭제 시 FALSE
 
     @Builder
     public Supporter(
             String name,
             String email
     ) {
-        this.name = name;
-        this.email = email;
+        this.supporterName = name;
+        this.supporterEmail = email;
     }
 
     @Builder
     public Supporter(
             String name,
             String email,
-            Boolean isDeleted
+            Boolean isActivated
     ) {
-        this.name = name;
-        this.email = email;
-        this.deleted = isDeleted;
+        this.supporterName = name;
+        this.supporterEmail = email;
+        this.activated = isActivated;
     }
 
     public void changeName(String name) {
-        this.name = name;
+        this.supporterName = name;
     }
 
     public void changeEmail(String email) {
-        this.email = email;
+        this.supporterEmail = email;
     }
 
     public static SupporterCreateRequestDTO toDTOForRequest(Supporter supporter) {
-        return new SupporterCreateRequestDTO(supporter.getName(), supporter.getEmail());
+        return new SupporterCreateRequestDTO(supporter.getSupporterName(), supporter.getSupporterEmail());
     }
 
     public static SupporterResponseDTO toDTOForResponse(Supporter supporter) {
-        return new SupporterResponseDTO(supporter.getName(), supporter.getEmail());
+        return new SupporterResponseDTO(supporter.getSupporterName(), supporter.getSupporterEmail());
     }
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
@@ -1,4 +1,9 @@
 package com.prgrms.wadiz.domain.supporter.repository;
 
-public interface SupporterRepository {
+import com.prgrms.wadiz.domain.supporter.entity.Supporter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SupporterRepository extends JpaRepository<Supporter, Long> {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
@@ -1,0 +1,4 @@
+package com.prgrms.wadiz.domain.supporter.repository;
+
+public interface SupporterRepository {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
@@ -8,17 +8,17 @@ import com.prgrms.wadiz.domain.supporter.repository.SupporterRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 @Service
 public class SupporterService {
 
     private SupporterRepository supporterRepository;
 
-
     public SupporterService(SupporterRepository supporterRepository) {
         this.supporterRepository = supporterRepository;
     }
+
+    @Transactional
 
     public SupporterResponseDTO createSupporter(SupporterCreateRequestDTO dto) {
         Supporter entity = dto.toEntity();

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
@@ -1,0 +1,48 @@
+package com.prgrms.wadiz.domain.supporter.service;
+
+import com.prgrms.wadiz.domain.supporter.dto.request.SupporterCreateRequestDTO;
+import com.prgrms.wadiz.domain.supporter.dto.request.SupporterUpdateRequestDTO;
+import com.prgrms.wadiz.domain.supporter.dto.response.SupporterResponseDTO;
+import com.prgrms.wadiz.domain.supporter.entity.Supporter;
+import com.prgrms.wadiz.domain.supporter.repository.SupporterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class SupporterService {
+
+    private SupporterRepository supporterRepository;
+
+
+    public SupporterService(SupporterRepository supporterRepository) {
+        this.supporterRepository = supporterRepository;
+    }
+
+    public SupporterResponseDTO createSupporter(SupporterCreateRequestDTO dto) {
+        Supporter entity = dto.toEntity();
+        Supporter savedEntity = supporterRepository.save(entity);
+        return Supporter.toDTOForResponse(savedEntity);
+    }
+
+    public SupporterResponseDTO getSupporter(Long id) {
+        Supporter supporter =supporterRepository.findById(id).orElseThrow(() -> new RuntimeException("수정할 id에 해당하는 서포터가 없습니다"));
+        return Supporter.toDTOForResponse(supporter);
+    }
+
+    public SupporterResponseDTO updateSupporter(Long id, SupporterUpdateRequestDTO dto) {
+        Supporter supporter =supporterRepository.findById(id).orElseThrow(() -> new RuntimeException("수정할 id에 해당하는 서포터가 없습니다"));
+        supporter.changeName(dto.name());
+        supporter.changeEmail(dto.email());
+        Supporter savedSupporter = supporterRepository.save(supporter);
+        return Supporter.toDTOForResponse(savedSupporter);
+    }
+
+
+    @Transactional
+    public void deleteSupporter(Long id) {
+        supporterRepository.deleteById(id);
+    }
+
+}

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/maker/service/MakerServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/maker/service/MakerServiceTest.java
@@ -1,0 +1,125 @@
+package com.prgrms.wadiz.domain.maker.service;
+
+import com.prgrms.wadiz.domain.maker.dto.request.MakerCreateRequestDTO;
+import com.prgrms.wadiz.domain.maker.dto.request.MakerModifyRequestDTO;
+import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
+import com.prgrms.wadiz.domain.maker.entity.Maker;
+import com.prgrms.wadiz.domain.maker.repository.MakerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MakerServiceTest {
+
+    @Mock
+    MakerRepository makerRepository;
+
+    @InjectMocks
+    MakerService makerService;
+
+    Maker maker;
+
+    @BeforeEach
+    void setUp() {
+        maker = new Maker("test", "testBrand", "test@gmail.com");
+    }
+
+    @Test
+    @DisplayName("메이커 회원가입을 성공한다.")
+    void signUpMakerTest() {
+        //given
+        MakerCreateRequestDTO makerCreateRequestDTO = new MakerCreateRequestDTO(
+                maker.getMakerName(),
+                maker.getMakerBrand(),
+                maker.getMakerEmail()
+        );
+
+        when(makerRepository.save(any(Maker.class))).then(AdditionalAnswers.returnsFirstArg());
+        Maker maker1 = makerCreateRequestDTO.toEntity();
+
+        //when
+        MakerResponseDTO makerResponseDTO = makerService.signUpMaker(makerCreateRequestDTO);
+        Maker maker2 = makerResponseDTO.toEntity();
+
+        //then
+        assertThat(maker1.getMakerId()).isEqualTo(maker2.getMakerId());
+    }
+
+    @Test
+    @DisplayName("메이커 정보를 수정한다.")
+    void modifyMakerTest() {
+        //given
+        MakerCreateRequestDTO makerCreateRequestDTO = new MakerCreateRequestDTO(
+                maker.getMakerName(),
+                maker.getMakerBrand(),
+                maker.getMakerEmail()
+        );
+
+        when(makerRepository.save(any(Maker.class))).then(AdditionalAnswers.returnsFirstArg());
+        Maker maker1 = makerCreateRequestDTO.toEntity();
+        Long makerId = maker1.getMakerId();
+
+        MakerResponseDTO makerResponseDTO = makerService.signUpMaker(makerCreateRequestDTO);
+
+        MakerModifyRequestDTO makerModifyRequestDTO = new MakerModifyRequestDTO(
+                "update",
+                "updateBrand",
+                "update@gmail.com"
+        );
+
+        when(makerRepository.findById(makerId)).thenReturn(Optional.of(maker1));
+
+
+        //when
+        MakerResponseDTO makerResponseDTO1 = makerService.modifyMaker(
+                makerResponseDTO.toEntity().getMakerId(),
+                makerModifyRequestDTO
+        );
+
+        //then
+        assertThat(makerResponseDTO.toEntity().getMakerId()).
+                isEqualTo(makerResponseDTO.toEntity().getMakerId());
+
+        assertThat(makerResponseDTO1.makerName())
+                .isEqualTo("update");
+    }
+
+    @Test
+    @DisplayName("메이커 soft-delete 테스트를 한다.")
+    void softDeleteTest() {
+        //given
+        MakerCreateRequestDTO makerCreateRequestDTO = new MakerCreateRequestDTO(
+                maker.getMakerName(),
+                maker.getMakerBrand(),
+                maker.getMakerEmail()
+        );
+
+        when(makerRepository.save(any(Maker.class))).then(AdditionalAnswers.returnsFirstArg());
+
+        MakerResponseDTO makerResponseDTO = makerService.signUpMaker(makerCreateRequestDTO);
+        Maker maker1 = makerResponseDTO.toEntity();
+        Long makerId = maker1.getMakerId();
+
+        //when
+        makerService.deleteMaker(makerId);
+
+        //then
+        verify(makerRepository).deleteById(makerId);
+    }
+}

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/supporter/service/SupporterServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/supporter/service/SupporterServiceTest.java
@@ -41,8 +41,8 @@ class SupporterServiceTest {
     void saveTest() {
         //given
         SupporterCreateRequestDTO supporterDTO = new SupporterCreateRequestDTO(
-                supporter.getName(),
-                supporter.getEmail()
+                supporter.getSupporterName(),
+                supporter.getSupporterEmail()
         );
 
         when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
@@ -54,7 +54,7 @@ class SupporterServiceTest {
         Supporter supporter2 = supporterResponse.toEntity();
 
         //then
-        assertThat(supporter1.getId()).isEqualTo(supporter2.getId());
+        assertThat(supporter1.getSupporterId()).isEqualTo(supporter2.getSupporterId());
     }
 
     @Test
@@ -62,15 +62,15 @@ class SupporterServiceTest {
     void updateTest() {
         //given
         SupporterCreateRequestDTO supporterDTO= new SupporterCreateRequestDTO(
-                supporter.getName(),
-                supporter.getEmail()
+                supporter.getSupporterName(),
+                supporter.getSupporterEmail()
         );
 
         when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
 
         SupporterResponseDTO responseDTO = supporterService.createSupporter(supporterDTO);
         Supporter supporter1 = responseDTO.toEntity();
-        Long supporter1Id = supporter1.getId();
+        Long supporter1Id = supporter1.getSupporterId();
 
         SupporterUpdateRequestDTO supporterUpdateRequestDTO = new SupporterUpdateRequestDTO(
                 "update",
@@ -81,13 +81,13 @@ class SupporterServiceTest {
 
         //when
         SupporterResponseDTO supporterResponseDTO = supporterService.updateSupporter(
-                supporter1.getId(),
+                supporter1.getSupporterId(),
                 supporterUpdateRequestDTO
         );
 
         //then
-        assertThat(supporterResponseDTO.toEntity().getId())
-                .isEqualTo(supporter1.getId());
+        assertThat(supporterResponseDTO.toEntity().getSupporterId())
+                .isEqualTo(supporter1.getSupporterId());
 
         assertThat(supporterResponseDTO.name())
                 .isEqualTo("update");
@@ -98,15 +98,15 @@ class SupporterServiceTest {
     void softDeleteTest() {
         //given
         SupporterCreateRequestDTO supporterDTO = new SupporterCreateRequestDTO(
-                supporter.getName(),
-                supporter.getEmail()
+                supporter.getSupporterName(),
+                supporter.getSupporterEmail()
         );
 
         when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
 
         SupporterResponseDTO responseDTO = supporterService.createSupporter(supporterDTO);
         Supporter supporter1 = responseDTO.toEntity();
-        Long supporter1Id = supporter1.getId();
+        Long supporter1Id = supporter1.getSupporterId();
 
         //when
         supporterService.deleteSupporter(supporter1Id);

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/supporter/service/SupporterServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/supporter/service/SupporterServiceTest.java
@@ -1,0 +1,117 @@
+package com.prgrms.wadiz.domain.supporter.service;
+
+import com.prgrms.wadiz.domain.supporter.dto.request.SupporterCreateRequestDTO;
+import com.prgrms.wadiz.domain.supporter.dto.request.SupporterUpdateRequestDTO;
+import com.prgrms.wadiz.domain.supporter.dto.response.SupporterResponseDTO;
+import com.prgrms.wadiz.domain.supporter.entity.Supporter;
+import com.prgrms.wadiz.domain.supporter.repository.SupporterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SupporterServiceTest {
+
+    @Mock
+    private SupporterRepository supporterRepository;
+
+    @InjectMocks
+    private SupporterService supporterService;
+
+    private Supporter supporter;
+
+    @BeforeEach
+    void setUp() {
+        supporter = new Supporter("testName", "test");
+    }
+
+    @Test
+    @DisplayName("서포터를 생성하여 저장한다")
+    void saveTest() {
+        //given
+        SupporterCreateRequestDTO supporterDTO = new SupporterCreateRequestDTO(
+                supporter.getName(),
+                supporter.getEmail()
+        );
+
+        when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
+
+        Supporter supporter1 = supporterDTO.toEntity();
+
+        //when
+        SupporterResponseDTO supporterResponse = supporterService.createSupporter(supporterDTO);
+        Supporter supporter2 = supporterResponse.toEntity();
+
+        //then
+        assertThat(supporter1.getId()).isEqualTo(supporter2.getId());
+    }
+
+    @Test
+    @DisplayName("서포터의 정보를 수정한다.")
+    void updateTest() {
+        //given
+        SupporterCreateRequestDTO supporterDTO= new SupporterCreateRequestDTO(
+                supporter.getName(),
+                supporter.getEmail()
+        );
+
+        when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
+
+        SupporterResponseDTO responseDTO = supporterService.createSupporter(supporterDTO);
+        Supporter supporter1 = responseDTO.toEntity();
+        Long supporter1Id = supporter1.getId();
+
+        SupporterUpdateRequestDTO supporterUpdateRequestDTO = new SupporterUpdateRequestDTO(
+                "update",
+                "update@gmail.com"
+        );
+
+        when(supporterRepository.findById(supporter1Id)).thenReturn(Optional.of(supporter1));
+
+        //when
+        SupporterResponseDTO supporterResponseDTO = supporterService.updateSupporter(
+                supporter1.getId(),
+                supporterUpdateRequestDTO
+        );
+
+        //then
+        assertThat(supporterResponseDTO.toEntity().getId())
+                .isEqualTo(supporter1.getId());
+
+        assertThat(supporterResponseDTO.name())
+                .isEqualTo("update");
+    }
+
+    @Test
+    @DisplayName("서포터를 soft-delete 한다.")
+    void softDeleteTest() {
+        //given
+        SupporterCreateRequestDTO supporterDTO = new SupporterCreateRequestDTO(
+                supporter.getName(),
+                supporter.getEmail()
+        );
+
+        when(supporterRepository.save(any(Supporter.class))).then(AdditionalAnswers.returnsFirstArg());
+
+        SupporterResponseDTO responseDTO = supporterService.createSupporter(supporterDTO);
+        Supporter supporter1 = responseDTO.toEntity();
+        Long supporter1Id = supporter1.getId();
+
+        //when
+        supporterService.deleteSupporter(supporter1Id);
+
+        //then
+        verify(supporterRepository).deleteById(supporter1Id);
+    }
+}


### PR DESCRIPTION
## 😇 use-case 배경 설명
<br>
Maker, Supporter의 기본적인 CRUD 기능입니다.

## 🍎 구현한 내용 설명
<br>
soft - delete의 경우  activated 필드 추가 + @SQLDelete 를 사용하였습니다.

## 📌리뷰어 리뷰 포인트
<br>
- soft- delete 방식 구현 코드의 흐름
- 단위테스트에서 mock 객체의 행위를 제대로 검증하는지
- 서비스 리턴 타입

## 👩‍💻테스트 
<br>

### Supporter Service crud Test
<img width="436" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/93516595/df42fbb2-b78c-4304-89cd-d379e8b41051">

### Maker Service crud Test
<img width="438" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/93516595/776d3989-5e7b-424d-b21c-7b627e6b9dbb">
