### PR TITLE
[Refactor] 재정의한 Project 도메인에 맞춰 Funding 관련 CRUD 수정

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingCreateRequestDTO.java
@@ -7,10 +7,10 @@ import java.time.LocalDateTime;
 
 @Builder
 public record FundingCreateRequestDTO(
-        FundingCategory fundingCategory,
         Integer fundingTargetAmount,
         LocalDateTime fundingStartAt,
-        LocalDateTime fundingEndAt
+        LocalDateTime fundingEndAt,
+        FundingCategory fundingCategory
 ) {
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
@@ -6,10 +6,10 @@ import com.prgrms.wadiz.domain.funding.FundingStatus;
 import java.time.LocalDateTime;
 
 public record FundingUpdateRequestDTO(
-        FundingCategory fundingCategory,
         Integer fundingTargetAmount,
         LocalDateTime fundingStartAt,
         LocalDateTime fundingEndAt,
+        FundingCategory fundingCategory,
         FundingStatus fundingStatus
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
@@ -1,0 +1,15 @@
+package com.prgrms.wadiz.domain.funding.dto.request;
+
+import com.prgrms.wadiz.domain.funding.FundingCategory;
+import com.prgrms.wadiz.domain.funding.FundingStatus;
+
+import java.time.LocalDateTime;
+
+public record FundingUpdateRequestDTO(
+        FundingCategory fundingCategory,
+        Integer fundingTargetAmount,
+        LocalDateTime fundingStartAt,
+        LocalDateTime fundingEndAt,
+        FundingStatus fundingStatus
+) {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
@@ -16,7 +16,7 @@ public record FundingResponseDTO(
         LocalDateTime fundingEndAt,
         FundingStatus fundingStatus
 ) {
-    public static FundingResponseDTO toResponseDTO(Funding funding) {
+    public static FundingResponseDTO from(Funding funding) {
         return FundingResponseDTO.builder()
                 .fundingId(funding.getFundingId())
                 .fundingCategory(funding.getFundingCategory())

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
@@ -10,19 +10,19 @@ import java.time.LocalDateTime;
 @Builder
 public record FundingResponseDTO(
         Long fundingId,
-        FundingCategory fundingCategory,
         Integer fundingTargetAmount,
         LocalDateTime fundingStartAt,
         LocalDateTime fundingEndAt,
+        FundingCategory fundingCategory,
         FundingStatus fundingStatus
 ) {
     public static FundingResponseDTO from(Funding funding) {
         return FundingResponseDTO.builder()
                 .fundingId(funding.getFundingId())
-                .fundingCategory(funding.getFundingCategory())
                 .fundingTargetAmount(funding.getFundingTargetAmount())
                 .fundingStartAt(funding.getFundingStartAt())
                 .fundingEndAt(funding.getFundingEndAt())
+                .fundingCategory(funding.getFundingCategory())
                 .fundingStatus(funding.getFundingStatus())
                 .build();
     }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
@@ -58,11 +58,11 @@ public class Funding extends BaseEntity {
     }
 
     public void updateFunding(
-            FundingStatus fundingStatus,
             Integer fundingTargetAmount,
-            FundingCategory fundingCategory,
             LocalDateTime fundingStartAt,
-            LocalDateTime fundingEndAt
+            LocalDateTime fundingEndAt,
+            FundingCategory fundingCategory,
+            FundingStatus fundingStatus
     ) {
         this.fundingTargetAmount = fundingTargetAmount;
         this.fundingStartAt = fundingStartAt;

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
@@ -56,4 +56,18 @@ public class Funding extends BaseEntity {
         this.fundingCategory = fundingCategory;
         this.fundingStatus = FundingStatus.OPEN;
     }
+
+    public void updateFunding(
+            FundingStatus fundingStatus,
+            Integer fundingTargetAmount,
+            FundingCategory fundingCategory,
+            LocalDateTime fundingStartAt,
+            LocalDateTime fundingEndAt
+    ) {
+        this.fundingTargetAmount = fundingTargetAmount;
+        this.fundingStartAt = fundingStartAt;
+        this.fundingEndAt = fundingEndAt;
+        this.fundingCategory = fundingCategory;
+        this.fundingStatus = fundingStatus;
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/repository/FundingRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/repository/FundingRepository.java
@@ -2,6 +2,15 @@ package com.prgrms.wadiz.domain.funding.repository;
 
 import com.prgrms.wadiz.domain.funding.entity.Funding;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface FundingRepository extends JpaRepository<Funding, Long> {
+    @Query("SELECT f FROM Funding f WHERE f.project.projectId = :projectId")
+    Optional<Funding> findByProjectId(@Param("projectId") Long projectId);
+
+    @Query("DELETE FROM Funding f WHERE f.project.projectId = :projectId")
+    void deleteByProjectId(@Param("projectId") Long projectId);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/service/FundingServiceFacade.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/service/FundingServiceFacade.java
@@ -1,10 +1,14 @@
 package com.prgrms.wadiz.domain.funding.service;
 
 import com.prgrms.wadiz.domain.funding.dto.request.FundingCreateRequestDTO;
+import com.prgrms.wadiz.domain.funding.dto.request.FundingUpdateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.funding.entity.Funding;
 import com.prgrms.wadiz.domain.funding.repository.FundingRepository;
+import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
 import com.prgrms.wadiz.domain.project.entity.Project;
+import com.prgrms.wadiz.global.util.exception.BaseException;
+import com.prgrms.wadiz.global.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,39 +17,57 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FundingServiceFacade {
     private final FundingRepository fundingRepository;
-    // private final ProjectRepository projectRepository;
 
     @Transactional
-    public Long createFunding(Long projectId, FundingCreateRequestDTO fundingCreateRequestDTO) {
-        Project project = projectRepository.findById(projectId).orElseThrow();
+    public Long createFunding(
+            ProjectServiceDTO projectServiceDTO,
+            FundingCreateRequestDTO fundingCreateRequestDTO
+    ) {
+        Project project = ProjectServiceDTO.toEntity(projectServiceDTO);
 
         Funding funding = Funding.builder()
+                .project(project)
                 .fundingCategory(fundingCreateRequestDTO.fundingCategory())
                 .fundingTargetAmount(fundingCreateRequestDTO.fundingTargetAmount())
                 .fundingStartAt(fundingCreateRequestDTO.fundingStartAt())
                 .fundingEndAt(fundingCreateRequestDTO.fundingEndAt())
                 .build();
 
-        project.updateFunding(funding);
-
         return fundingRepository.save(funding).getFundingId();
     }
 
-    @Transactional
-    public FundingResponseDTO getFunding(Long projectId) {
-//        Funding funding = fundingRepository.findById(fundingId)
-//                .orElseThrow(() -> new BaseException(ErrorCode.FUNDING_NOT_FOUND));
-
-        fundingRepository.
-
-        return FundingResponseDTO.toResponseDTO(funding);
-    }
-
-    public boolean isFundingExist(Long projectId) {
-        return false;
-    }
-
+    @Transactional(readOnly = true)
     public FundingResponseDTO getFundingByProjectId(Long projectId) {
-        return null;
+        Funding funding = fundingRepository.findByProjectId(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.FUNDING_NOT_FOUND));
+
+        return FundingResponseDTO.from(funding);
+    }
+
+    @Transactional
+    public void updateFunding(
+            Long projectId,
+            FundingUpdateRequestDTO fundingUpdateRequestDTO
+    ) {
+        Funding funding = fundingRepository.findByProjectId(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.FUNDING_NOT_FOUND));
+
+        funding.updateFunding(
+                fundingUpdateRequestDTO.fundingStatus(),
+                fundingUpdateRequestDTO.fundingTargetAmount(),
+                fundingUpdateRequestDTO.fundingCategory(),
+                fundingUpdateRequestDTO.fundingStartAt(),
+                fundingUpdateRequestDTO.fundingEndAt()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isFundingExist(Long projectId) {
+        return fundingRepository.findByProjectId(projectId).isPresent();
+    }
+
+    @Transactional
+    public void deleteFunding(Long projectId) {
+        fundingRepository.deleteByProjectId(projectId);
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -18,15 +18,12 @@ public class ProjectController {
     public ResponseEntity<ResponseTemplate> startProject(@PathVariable Long makerId) {
         ProjectResponseDTO projectResponseDTO = projectService.startProject(makerId);
 
-        return ResponseEntity.ok(ResponseFactory.getSingleResult(projectResponseDTO));
-    }
-
-    @PostMapping("/{makerId}/{projectId}")
+    @PostMapping("/{projectId}/maker/{makerId}")
     public ResponseEntity<ResponseTemplate> createProject(
-            @PathVariable Long makerId,
-            @PathVariable Long projectId
+            @PathVariable Long projectId,
+            @PathVariable Long makerId
     ) {
-        projectService.createProject(makerId, projectId);
+        projectService.createProject(projectId, makerId);
 
         return ResponseEntity.ok(ResponseFactory.getSuccessResult());
     }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -1,5 +1,8 @@
 package com.prgrms.wadiz.domain.project.controller;
 
+import com.prgrms.wadiz.domain.funding.dto.request.FundingCreateRequestDTO;
+import com.prgrms.wadiz.domain.funding.dto.request.FundingUpdateRequestDTO;
+import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
 import com.prgrms.wadiz.domain.project.service.ProjectService;
 import com.prgrms.wadiz.global.util.resTemplate.ResponseFactory;
@@ -35,7 +38,37 @@ public class ProjectController {
         return ResponseEntity.ok(ResponseFactory.getSingleResult(projectResponseDTO));
     }
 
+    @PostMapping("/{projectId}/fundings/new")
+    public ResponseEntity<ResponseTemplate> createFunding(
+            @PathVariable Long projectId,
+            @RequestBody FundingCreateRequestDTO fundingCreateRequestDTO
+    ) {
+        projectService.createFunding(projectId, fundingCreateRequestDTO);
 
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
 
+    @GetMapping("/{projectId}/fundings")
+    public ResponseEntity<ResponseTemplate> getFunding(@PathVariable Long projectId) {
+        FundingResponseDTO fundingResponseDTO = projectService.getFunding(projectId);
 
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(fundingResponseDTO));
+    }
+
+    @PutMapping("/{projectId}/fundings")
+    public ResponseEntity<ResponseTemplate> updateFunding(
+            @PathVariable Long projectId,
+            @RequestBody FundingUpdateRequestDTO fundingUpdateRequestDTO
+    ) {
+        projectService.updateFunding(projectId, fundingUpdateRequestDTO);
+
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
+
+    @DeleteMapping("/{projectId}/fundings")
+    public ResponseEntity<ResponseTemplate> deleteFunding(@PathVariable Long projectId) {
+        projectService.deleteFunding(projectId);
+
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/ProjectServiceDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/ProjectServiceDTO.java
@@ -1,0 +1,23 @@
+package com.prgrms.wadiz.domain.project.dto;
+
+import com.prgrms.wadiz.domain.project.ProjectStatus;
+import com.prgrms.wadiz.domain.project.entity.Project;
+import lombok.Builder;
+
+@Builder
+public record ProjectServiceDTO(
+        Long projectId,
+        ProjectStatus projectStatus
+        // TODO: Maker에 대한 lazy loading을 어떻게 처리할 것인지 + 과연 모든 필드가 다 필요한 것인지 확인해보기
+) {
+    public static ProjectServiceDTO from(Project project) {
+        return ProjectServiceDTO.builder()
+                .projectId(project.getProjectId())
+                .projectStatus(project.getProjectStatus())
+                .build();
+    }
+
+    public static Project toEntity(ProjectServiceDTO projectServiceDTO) {
+        return Project.builder().build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
@@ -1,11 +1,14 @@
 package com.prgrms.wadiz.domain.project.service;
 
+import com.prgrms.wadiz.domain.funding.dto.request.FundingCreateRequestDTO;
+import com.prgrms.wadiz.domain.funding.dto.request.FundingUpdateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.funding.service.FundingServiceFacade;
 import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
 import com.prgrms.wadiz.domain.maker.entity.Maker;
 import com.prgrms.wadiz.domain.maker.service.MakerService;
 import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
+import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
 import com.prgrms.wadiz.domain.reward.dto.response.RewardResponseDTO;
 import com.prgrms.wadiz.global.util.exception.ErrorCode;
 import com.prgrms.wadiz.domain.post.service.PostServiceFacade;
@@ -77,5 +80,30 @@ public class ProjectService {
         return ProjectResponseDTO.of(projectId, makerResponseDTO, postServiceDTO, fundingServiceDTO, rewardServiceDTOs);
     }
 
-    //하위 도메인 생성 : 하위 도메인 서비스에게 생성을 위임한다.
+    @Transactional
+    public void createFunding(Long projectId, FundingCreateRequestDTO fundingCreateRequestDTO) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.PROJECT_NOT_FOUND));
+        ProjectServiceDTO projectServiceDTO = ProjectServiceDTO.from(project);
+
+        fundingServiceFacade.createFunding(projectServiceDTO, fundingCreateRequestDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public FundingResponseDTO getFunding(Long projectId) {
+        return fundingServiceFacade.getFundingByProjectId(projectId);
+    }
+
+    @Transactional
+    public void updateFunding(
+            Long projectId,
+            FundingUpdateRequestDTO fundingUpdateRequestDTO
+    ) {
+        fundingServiceFacade.updateFunding(projectId, fundingUpdateRequestDTO);
+    }
+
+    @Transactional
+    public void deleteFunding(Long projectId) {
+        fundingServiceFacade.deleteFunding(projectId);
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
@@ -34,19 +34,7 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
 
     @Transactional
-    public ProjectResponseDTO startProject(Long makerId) {
-        MakerServiceDTO makerServiceDTO = makerService.getMakerDTO(makerId);
-        Maker maker = MakerServiceDTO.toEntity(makerServiceDTO);
-
-        Project project = Project.builder()
-                .maker(maker)
-                .build();
-
-        return ProjectResponseDTO.of(projectRepository.save(project).getProjectId());
-    }
-
-    @Transactional
-    public void createProject(Long makerId, Long projectId) {
+    public void createProject(Long projectId, Long makerId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.PROJECT_NOT_FOUND));
 


### PR DESCRIPTION
## 😇 use-case 배경 설명
supporter가 project 등록 전에 funding에 대한 정보를 관리할 수 있어야 한다.
<br>

## 🍎 구현한 내용 설명
supporter는 project 등록 전 funding에 관한 정보를 생성 및 조회, 수정, 삭제할 수 있다.
<br>

## 📌리뷰어 리뷰 포인트
project에 대한 정보를 하위 서비스로 전파하는 방식이 이런 식으로 의도한게 맞는지 확인해주시면 감사하겠습니다~!
<br>

## 👩‍💻테스트 <!--선택-->
![스크린샷 2023-09-04 오후 11 34 48](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/05ff7902-0c46-4105-a87b-caa252244c04)

