### PR TITLE
[Refactor] 재정의한 Project 도메인에 맞춰 Post 관련 CRUD 수정

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostUpdateRequestDTO.java
@@ -1,0 +1,9 @@
+package com.prgrms.wadiz.domain.post.dto.request;
+
+public record PostUpdateRequestDTO(
+        String postTitle,
+        String postDescription,
+        String postThumbNailImage,
+        String postContentImage
+) {
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/response/PostResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/response/PostResponseDTO.java
@@ -12,7 +12,7 @@ public record PostResponseDTO(
         String postContentImage
 ) {
 
-    public static PostResponseDTO toResponseDTO(Post post) {
+    public static PostResponseDTO from(Post post) {
         return PostResponseDTO.builder()
                 .postId(post.getPostId())
                 .postTitle(post.getPostTitle())

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/entity/Post.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/entity/Post.java
@@ -48,4 +48,16 @@ public class Post extends BaseEntity {
         this.postThumbNailImage = postThumbNailImage;
         this.postContentImage = postContentImage;
     }
+
+    public void updatePost(
+            String postTitle,
+            String postDescription,
+            String postThumbNailImage,
+            String postContentImage
+    ) {
+        this.postTitle = postTitle;
+        this.postDescription = postDescription;
+        this.postThumbNailImage = postThumbNailImage;
+        this.postContentImage = postContentImage;
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/repository/PostRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/repository/PostRepository.java
@@ -2,6 +2,15 @@ package com.prgrms.wadiz.domain.post.repository;
 
 import com.prgrms.wadiz.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query("SELECT p FROM Post p WHERE p.project.projectId = :projectId")
+    Optional<Post> findByProjectId(@Param("projectId") Long projectId);
+
+    @Query("DELETE FROM Post p WHERE p.project.projectId = :projectId")
+    void deleteByProjectId(@Param("projectId") Long projectId);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/service/PostServiceFacade.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/service/PostServiceFacade.java
@@ -1,9 +1,12 @@
 package com.prgrms.wadiz.domain.post.service;
 
 import com.prgrms.wadiz.domain.post.dto.request.PostCreateRequestDTO;
+import com.prgrms.wadiz.domain.post.dto.request.PostUpdateRequestDTO;
 import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
 import com.prgrms.wadiz.domain.post.entity.Post;
 import com.prgrms.wadiz.domain.post.repository.PostRepository;
+import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
+import com.prgrms.wadiz.domain.project.entity.Project;
 import com.prgrms.wadiz.global.util.exception.BaseException;
 import com.prgrms.wadiz.global.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,30 +19,54 @@ public class PostServiceFacade {
     private final PostRepository postRepository;
 
     @Transactional
-    public Post createPost(PostCreateRequestDTO postCreateRequestDTO) {
+    public Long createPost(
+            ProjectServiceDTO projectServiceDTO,
+            PostCreateRequestDTO postCreateRequestDTO
+    ) {
+        Project project = ProjectServiceDTO.toEntity(projectServiceDTO);
+
         Post post = Post.builder()
+                .project(project)
                 .postTitle(postCreateRequestDTO.postTitle())
                 .postDescription(postCreateRequestDTO.postDescription())
                 .postThumbNailImage(postCreateRequestDTO.postThumbNailImage())
                 .postContentImage(postCreateRequestDTO.postContentImage())
                 .build();
 
-        return postRepository.save(post);
+        return postRepository.save(post).getPostId();
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponseDTO getPostByProjectId(Long projectId) {
+        Post post = postRepository.findByProjectId(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
+
+        return PostResponseDTO.from(post);
     }
 
     @Transactional
-    public PostResponseDTO getPost(Long postId) {
-        Post post = postRepository.findById(postId)
+    public void updatePost(
+            Long projectId,
+            PostUpdateRequestDTO postUpdateRequestDTO
+    ) {
+        Post post = postRepository.findByProjectId(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
 
-        return PostResponseDTO.toResponseDTO(post);
+        post.updatePost(
+                postUpdateRequestDTO.postTitle(),
+                postUpdateRequestDTO.postDescription(),
+                postUpdateRequestDTO.postThumbNailImage(),
+                postUpdateRequestDTO.postContentImage()
+        );
     }
 
+    @Transactional(readOnly = true)
     public boolean isPostExist(Long projectId) {
-        return false;
+        return postRepository.findByProjectId(projectId).isPresent();
     }
 
-    public PostResponseDTO getPostByProjectId(Long projectId) {
-        return null;
+    @Transactional
+    public void deletePost(Long projectId) {
+        postRepository.deleteByProjectId(projectId);
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -1,5 +1,8 @@
 package com.prgrms.wadiz.domain.project.controller;
 
+import com.prgrms.wadiz.domain.post.dto.request.PostCreateRequestDTO;
+import com.prgrms.wadiz.domain.post.dto.request.PostUpdateRequestDTO;
+import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
 import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
 import com.prgrms.wadiz.domain.project.service.ProjectService;
 import com.prgrms.wadiz.global.util.resTemplate.ResponseFactory;
@@ -39,6 +42,37 @@ public class ProjectController {
     }
 
 
+    @PostMapping("/{projectId}/posts/new")
+    public ResponseEntity<ResponseTemplate> createPost(
+            @PathVariable Long projectId,
+            @RequestBody PostCreateRequestDTO postCreateRequestDTO
+    ) {
+        projectService.createPost(projectId, postCreateRequestDTO);
 
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
 
+    @GetMapping("/{projectId}/posts")
+    public ResponseEntity<ResponseTemplate> getPost(@PathVariable Long projectId) {
+        PostResponseDTO postResponseDTO = projectService.getPost(projectId);
+
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(postResponseDTO));
+    }
+
+    @PutMapping("/{projectId}/posts")
+    public ResponseEntity<ResponseTemplate> updatePost(
+            @PathVariable Long projectId,
+            @RequestBody PostUpdateRequestDTO postUpdateRequestDTO
+    ) {
+        projectService.updatePost(projectId, postUpdateRequestDTO);
+
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
+
+    @DeleteMapping("/{projectId}/posts")
+    public ResponseEntity<ResponseTemplate> deletePost(@PathVariable Long projectId) {
+        projectService.deletePost(projectId);
+
+        return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectService.java
@@ -6,7 +6,10 @@ import com.prgrms.wadiz.domain.maker.dto.MakerServiceDTO;
 import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
 import com.prgrms.wadiz.domain.maker.entity.Maker;
 import com.prgrms.wadiz.domain.maker.service.MakerService;
+import com.prgrms.wadiz.domain.post.dto.request.PostCreateRequestDTO;
+import com.prgrms.wadiz.domain.post.dto.request.PostUpdateRequestDTO;
 import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
+import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
 import com.prgrms.wadiz.domain.reward.dto.response.RewardResponseDTO;
 import com.prgrms.wadiz.global.util.exception.ErrorCode;
 import com.prgrms.wadiz.domain.post.service.PostServiceFacade;
@@ -78,4 +81,33 @@ public class ProjectService {
         return ProjectResponseDTO.of(projectId, makerResponseDTO, postServiceDTO, fundingServiceDTO, rewardServiceDTOs);
     }
 
+    @Transactional
+    public void createPost(
+            Long projectId,
+            PostCreateRequestDTO postCreateRequestDTO
+    ) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.PROJECT_NOT_FOUND));
+        ProjectServiceDTO projectServiceDTO = ProjectServiceDTO.from(project);
+
+        postServiceFacade.createPost(projectServiceDTO, postCreateRequestDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponseDTO getPost(Long projectId) {
+        return postServiceFacade.getPostByProjectId(projectId);
+    }
+
+    @Transactional
+    public void updatePost(
+            Long projectId,
+            PostUpdateRequestDTO postUpdateRequestDTO
+    ) {
+        postServiceFacade.updatePost(projectId, postUpdateRequestDTO);
+    }
+
+    @Transactional
+    public void deletePost(Long projectId) {
+        postServiceFacade.deletePost(projectId);
+    }
 }


### PR DESCRIPTION
## 😇 use-case 배경 설명
supporter가 project 등록 전에 post에 대한 정보를 관리할 수 있어야 한다.
<br>

## 🍎 구현한 내용 설명
supporter는 project 등록 전 post에 관한 정보를 생성 및 조회, 수정, 삭제할 수 있다.
<br>

## 📌리뷰어 리뷰 포인트
이전에 올린 funding pr과 거의 유사해서 funding pr을 보고 오셨다면, 
중간에 코드 뭐 빼먹은 거 없는지 정도만 확인해주셔도 될 것 같습니다!
<br>

## 👩‍💻테스트 <!--선택-->
![스크린샷 2023-09-05 오전 11 51 38](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/3a768603-fb1d-4221-a044-089e9914cd17)

