### PR TITLE
[Feat] Order 시스템 :  서포터가 단건 주문을 확인, 서포터가 여러 요약된 주문 내역을 확인, 메이커가 런칭한 프로젝트 주문 확인

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/controller/OrderController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/controller/OrderController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("orders/")
 @RequiredArgsConstructor
@@ -27,13 +29,32 @@ public class OrderController {
     }
 
     @GetMapping("{orderId}/supporters/{supporterId}")
-    public ResponseEntity<ResponseTemplate> getPurchase(
+    public ResponseEntity<ResponseTemplate> getSupporterPurchase(
             @PathVariable Long orderId,
             @PathVariable Long supporterId
     ){
-        OrderResponseDTO orderResponseDTO = orderService.getPurchase(orderId, supporterId);
+        OrderResponseDTO orderResponseDTO = orderService.getSupporterPurchase(orderId, supporterId);
 
         return ResponseEntity.ok(ResponseFactory.getSingleResult(orderResponseDTO));
+    }
+
+    @GetMapping("supporters/{supporterId}")
+    public ResponseEntity<ResponseTemplate> getSupporterPurchaseHistory(
+            @PathVariable Long supporterId
+    ){
+        List<OrderResponseDTO> orderResponseDTOs = orderService.getSupporterPurchaseHistory(supporterId);
+
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(orderResponseDTOs));
+    }
+
+    @GetMapping("projects/{projectId}/makers/{makerId}")
+    public ResponseEntity<ResponseTemplate> getMakerProjectOrders(
+            @PathVariable Long projectId,
+            @PathVariable Long makerId
+    ){
+        List<OrderResponseDTO> orderResponseDTOs = orderService.getMakerProjectOrders(projectId,makerId);
+
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(orderResponseDTOs));
     }
 
     @PutMapping("{supporterId}/{orderId}")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/dto/response/OrderResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/dto/response/OrderResponseDTO.java
@@ -1,9 +1,11 @@
 package com.prgrms.wadiz.domain.order.dto.response;
 
+import com.prgrms.wadiz.domain.funding.FundingCategory;
 import com.prgrms.wadiz.domain.order.OrderStatus;
 import com.prgrms.wadiz.domain.orderReward.dto.response.OrderRewardResponseDTO;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -12,17 +14,10 @@ public record OrderResponseDTO(
         String postTitle,
         String makerBrand,
         List<OrderRewardResponseDTO> orderRewardResponseDTOs,
+        FundingCategory fundingCategory,
+        LocalDateTime createdAt,
         OrderStatus orderStatus
 ) {
-//    public static OrderResponseDTO from(Order order){
-//        return OrderResponseDTO.builder()
-//                .orderId(order.getOrderId())
-//                .projectId(order.getProject().getProjectId())
-//                .makerBrand(order.getProject().getMaker().getMakerBrand())
-//                .orderRewards(order.getOrderRewards())
-//                .orderStatus(order.getOrderStatus())
-//                .build();
-//    }
 
     public static OrderResponseDTO of(
             Long orderId,
@@ -37,6 +32,34 @@ public record OrderResponseDTO(
                 .makerBrand(makerBrand)
                 .orderRewardResponseDTOs(orderRewardResponseDTOs)
                 .orderStatus(orderStatus)
+                .build();
+    }
+
+    public static OrderResponseDTO of(
+            Long orderId,
+            List<OrderRewardResponseDTO> orderRewardResponseDTOs,
+            OrderStatus orderStatus
+    ){
+        return OrderResponseDTO.builder()
+                .orderId(orderId)
+                .orderRewardResponseDTOs(orderRewardResponseDTOs)
+                .orderStatus(orderStatus)
+                .build();
+    }
+
+    public static OrderResponseDTO of(
+            Long orderId,
+            String postTitle,
+            String makerBrand,
+            FundingCategory fundingCategory,
+            LocalDateTime createdAt
+    ){
+        return OrderResponseDTO.builder()
+                .orderId(orderId)
+                .postTitle(postTitle)
+                .makerBrand(makerBrand)
+                .fundingCategory(fundingCategory)
+                .createdAt(createdAt)
                 .build();
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/repository/OrderRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/repository/OrderRepository.java
@@ -3,5 +3,11 @@ package com.prgrms.wadiz.domain.order.repository;
 import com.prgrms.wadiz.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface OrderRepository extends JpaRepository<Order,Long> {
+    Optional<List<Order>> findBySupporterId(Long supporterId);
+
+    Optional<List<Order>> findByProjectId(Long projectId);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.prgrms.wadiz.domain.order.service;
 
+import com.prgrms.wadiz.domain.funding.FundingCategory;
+import com.prgrms.wadiz.domain.funding.repository.FundingRepository;
 import com.prgrms.wadiz.domain.order.dto.request.OrderCreateRequestDTO;
 import com.prgrms.wadiz.domain.order.dto.response.OrderResponseDTO;
 import com.prgrms.wadiz.domain.order.entity.Order;
@@ -31,6 +33,7 @@ public class OrderService {
     private final SupporterRepository supporterRepository;
     private final RewardRepository rewardRepository;
     private final PostRepository postRepository;
+    private final FundingRepository fundingRepository;
 
     // 주문 생성
     @Transactional
@@ -81,20 +84,13 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public OrderResponseDTO getPurchase(
+    public OrderResponseDTO getSupporterPurchase(
             Long supporterId,
             Long orderId
     ) {
-        Order order = orderRepository.findById(orderId).orElseThrow(() -> {
-            log.error("Order {} is not found", orderId);
+        Order order = getOrderInfo(orderId);
 
-            return new BaseException(ErrorCode.ORDER_NOT_FOUND);
-        });
-
-        if (!order.getSupporter().getSupporterId().equals(supporterId)){
-
-            throw new BaseException(ErrorCode.INVALID_ACCESS);
-        }
+        validateSupporter(supporterId, order.getSupporter().getSupporterId());
 
         Long projectId = order.getProject().getProjectId();
         String postTitle = postRepository.findByProjectId(projectId).orElseThrow(() -> {
@@ -109,7 +105,6 @@ public class OrderService {
                         orderReward.getReward().getRewardDescription(),
                         orderReward.getOrderRewardPrice(),
                         orderReward.getOrderRewardQuantity()
-
                 ))
                 .collect(Collectors.toList());
 
@@ -122,22 +117,113 @@ public class OrderService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public List<OrderResponseDTO> getSupporterPurchaseHistory(Long supporterId) {
+        List<Order> orders = orderRepository.findBySupporterId(supporterId)
+                .orElseThrow(() -> {
+                    log.error("Orders are not found by supporterId : {}", supporterId);
+
+                    throw new BaseException(ErrorCode.ORDER_COUNT_ERROR);
+                });
+
+        validateSupporter(supporterId,orders.get(0).getSupporter().getSupporterId());
+
+        List<OrderResponseDTO> orderResponseDTOs = orders.stream()
+                .map(order -> {
+                    String postTitle = postRepository.findByProjectId(order.getProject().getProjectId())
+                            .orElseThrow(() -> {
+                                log.error("post is not found");
+
+                                return new BaseException(ErrorCode.POST_NOT_FOUND);
+                            }).getPostTitle();
+
+                    FundingCategory fundingCategory = fundingRepository.findByProjectId(order.getProject().getProjectId())
+                            .orElseThrow(() -> {
+                                log.error("post is not found");
+
+                                return new BaseException(ErrorCode.FUNDING_NOT_FOUND);
+                            }).getFundingCategory();
+
+                    String makerBrand = order.getProject().getMaker().getMakerBrand();
+
+                    return OrderResponseDTO.of(
+                            order.getOrderId(),
+                            postTitle,
+                            makerBrand,
+                            fundingCategory,
+                            order.getCreatedAt()
+                    );
+                }).collect(Collectors.toList());
+
+
+        return orderResponseDTOs;
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderResponseDTO> getMakerProjectOrders(Long projectId, Long makerId) {
+        List<Order> orders = orderRepository.findByProjectId(projectId)
+                .orElseThrow(() -> {
+                    log.error("Orders are not found by projectId : {}", projectId);
+
+                    throw new BaseException(ErrorCode.ORDER_COUNT_ERROR);
+                });
+
+        validateMaker(makerId,orders.get(0).getProject().getMaker().getMakerId());
+
+        List<OrderResponseDTO> orderResponseDTOs = orders.stream()
+                .map(order -> {
+                    List<OrderRewardResponseDTO> orderRewardResponseDTOs = order.getOrderRewards().stream()
+                            .map(orderReward -> OrderRewardResponseDTO.of(
+                                    orderReward.getReward().getRewardName(),
+                                    orderReward.getReward().getRewardDescription(),
+                                    orderReward.getOrderRewardPrice(),
+                                    orderReward.getOrderRewardQuantity()
+                            ))
+                            .collect(Collectors.toList());
+
+                    return OrderResponseDTO.of(
+                            order.getOrderId(),
+                            orderRewardResponseDTOs,
+                            order.getOrderStatus()
+                    );
+                }).collect(Collectors.toList());
+
+        return orderResponseDTOs;
+    }
+
     @Transactional
     public void cancelOrder(
             Long supporterId,
             Long orderId
     ) {
+        Order order = getOrderInfo(orderId);
+
+        validateSupporter(supporterId, order.getSupporter().getSupporterId());
+
+        order.cancel();
+    }
+
+    private void validateSupporter(Long supporterId, Long orderSupporterId) {
+        if (!orderSupporterId.equals(supporterId)){
+
+            throw new BaseException(ErrorCode.INVALID_ACCESS);
+        }
+    }
+
+    private void validateMaker(Long makerId, Long projectMakerId) {
+        if(!makerId.equals(projectMakerId)){
+
+            throw new BaseException(ErrorCode.INVALID_ACCESS);
+        }
+    }
+
+    private Order getOrderInfo(Long orderId) {
         Order order = orderRepository.findById(orderId).orElseThrow(() -> {
             log.error("Order {} is not found", orderId);
 
             return new BaseException(ErrorCode.ORDER_NOT_FOUND);
         });
-
-        if (!order.getSupporter().getSupporterId().equals(supporterId)){
-
-            throw new BaseException(ErrorCode.INVALID_ACCESS);
-        }
-
-        order.cancel();
+        return order;
     }
+
 }


### PR DESCRIPTION
## 😇 use-case 배경 설명
서포터가 주문을 확인, 메이커가 주문을 확인하는 로직이 필요했다.

## 🍎 구현한 내용 설명
<br>
객체 그래프탐색을 통한 정보 조회, 일반 주문 조회 에 대한 응답 형식을 와디즈 홈페이지를 참조하면서 기획함

## 📌리뷰어 리뷰 포인트
<br>


## 📝api 명세 <!--선택-->
<br>
너무 길어서 생략

## 👩‍💻테스트 <!--선택-->
<br>
