### PR TITLE
[Feat] 펀딩 시스템: WDZL-105 Project 개설 전, Post에 대한 검증

### DIFF
--- a/wadiz/build.gradle
+++ b/wadiz/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostCreateRequestDTO.java
@@ -2,11 +2,21 @@ package com.prgrms.wadiz.domain.post.dto.request;
 
 import lombok.Builder;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 @Builder
 public record PostCreateRequestDTO(
+        @NotBlank(message = "제목은 비워둘 수 없습니다.")
         String postTitle,
+
+        @NotBlank(message = "상세 설명은 비워둘 수 없습니다.")
         String postDescription,
+
+        @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
         String postThumbNailImage,
+
+        @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
         String postContentImage
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/dto/request/PostUpdateRequestDTO.java
@@ -1,9 +1,19 @@
 package com.prgrms.wadiz.domain.post.dto.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 public record PostUpdateRequestDTO(
+        @NotBlank(message = "제목은 비워둘 수 없습니다.")
         String postTitle,
+
+        @NotBlank(message = "상세 설명은 비워둘 수 없습니다.")
         String postDescription,
+
+        @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
         String postThumbNailImage,
+
+        @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
         String postContentImage
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/entity/Post.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/entity/Post.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @Entity
 @Table(name = "posts")
@@ -22,16 +24,20 @@ public class Post extends BaseEntity {
     private Project project;
 
     @Column(nullable = false)
+    @NotBlank(message = "제목은 비워둘 수 없습니다.")
     private String postTitle;
 
     @Lob
     @Column(nullable = false)
+    @NotBlank(message = "상세 설명은 비워둘 수 없습니다.")
     private String postDescription;
 
     @Column(nullable = false)
+    @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
     private String postThumbNailImage;
 
     @Column(nullable = false)
+    @Pattern(regexp = "^https?://.*\\.(?:png|jpg|jpeg|gif)$", message = "올바른 이미지 URL 형식이 아닙니다.")
     private String postContentImage;
 
     @Builder

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/api/projects")
 @RequiredArgsConstructor
@@ -46,7 +48,7 @@ public class ProjectController {
     @PostMapping("/{projectId}/fundings/new")
     public ResponseEntity<ResponseTemplate> createFunding(
             @PathVariable Long projectId,
-            @RequestBody FundingCreateRequestDTO fundingCreateRequestDTO
+            @RequestBody @Valid FundingCreateRequestDTO fundingCreateRequestDTO
     ) {
         projectService.createFunding(projectId, fundingCreateRequestDTO);
 
@@ -63,7 +65,7 @@ public class ProjectController {
     @PutMapping("/{projectId}/fundings")
     public ResponseEntity<ResponseTemplate> updateFunding(
             @PathVariable Long projectId,
-            @RequestBody FundingUpdateRequestDTO fundingUpdateRequestDTO
+            @RequestBody @Valid FundingUpdateRequestDTO fundingUpdateRequestDTO
     ) {
         projectService.updateFunding(projectId, fundingUpdateRequestDTO);
 
@@ -80,7 +82,7 @@ public class ProjectController {
     @PostMapping("/{projectId}/posts/new")
     public ResponseEntity<ResponseTemplate> createPost(
             @PathVariable Long projectId,
-            @RequestBody PostCreateRequestDTO postCreateRequestDTO
+            @RequestBody @Valid PostCreateRequestDTO postCreateRequestDTO
     ) {
         projectService.createPost(projectId, postCreateRequestDTO);
 
@@ -97,7 +99,7 @@ public class ProjectController {
     @PutMapping("/{projectId}/posts")
     public ResponseEntity<ResponseTemplate> updatePost(
             @PathVariable Long projectId,
-            @RequestBody PostUpdateRequestDTO postUpdateRequestDTO
+            @RequestBody @Valid PostUpdateRequestDTO postUpdateRequestDTO
     ) {
         projectService.updatePost(projectId, postUpdateRequestDTO);
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     REWARD_NOT_FOUND(225, "리워드 정보를 찾을 수 없습니다."),
 
     POST_NOT_FOUND(-2000, "게시글 정보를 찾을 수 없습니다."),
-    ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." );
+    ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." ),
+    PROJECT_ACCESS_DENY(444, "프로젝트가 개설된 이후로는 접근할 수 없습니다.");
 
     private int code;
     private String errorMessage;


### PR DESCRIPTION
## 😇 use-case 배경 설명
Post에 대한 정보를 등록 및 수정할 때 각 필드에 적합하지 않은 값을 받는지 검증해줘야한다.
Maker는 Project가 개설된 후로는 Post에 대한 정보는 수정 및 삭제를 할 수 없다.

## 🍎 구현한 내용 설명
Request Body로 받는 내용을 bean validation으로 검증한다.
db에 쿼리가 날아가기 전 엔티티 필드에 bean validation으로 대해서 검증한다.

## 📌리뷰어 리뷰 포인트
예외적인 값에 대해 검증을 잘 수행했는지 확인해주시면 좋겠습니다~!

## 👩‍💻테스트 <!--선택-->
<img width="491" alt="스크린샷 2023-09-06 오후 7 10 36" src="https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/9d848428-2d8d-4d0f-9b59-b8e8e1385f2c">

