### PR TITLE
[Feat] 펀딩 시스템: WDZL-106 Project 개설 전, Funding에 대한 검증

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingCreateRequestDTO.java
@@ -1,15 +1,25 @@
 package com.prgrms.wadiz.domain.funding.dto.request;
 
 import com.prgrms.wadiz.domain.funding.FundingCategory;
+import com.prgrms.wadiz.global.annotation.ValidEnum;
 import lombok.Builder;
 
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.Min;
 import java.time.LocalDateTime;
 
 @Builder
 public record FundingCreateRequestDTO(
+        @Min(value = 0, message = "펀딩 모집 금액은 0이상의 정수만 허용됩니다.")
         Integer fundingTargetAmount,
+
+        @FutureOrPresent(message = "펀딩 시작 시점을 과거 시각으로 설정할 수 없습니다.")
         LocalDateTime fundingStartAt,
+
+        @FutureOrPresent(message = "펀딩 종료 시점을 과거 시각으로 설정할 수 없습니다.")
         LocalDateTime fundingEndAt,
+
+        @ValidEnum(enumClass = FundingCategory.class, message = "존재하지 않는 카테고리 입니다.")
         FundingCategory fundingCategory
 ) {
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/request/FundingUpdateRequestDTO.java
@@ -2,14 +2,26 @@ package com.prgrms.wadiz.domain.funding.dto.request;
 
 import com.prgrms.wadiz.domain.funding.FundingCategory;
 import com.prgrms.wadiz.domain.funding.FundingStatus;
+import com.prgrms.wadiz.global.annotation.ValidEnum;
 
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.Min;
 import java.time.LocalDateTime;
 
 public record FundingUpdateRequestDTO(
+        @Min(value = 0, message = "펀딩 모집 금액은 0이상의 정수만 허용됩니다.")
         Integer fundingTargetAmount,
+
+        @FutureOrPresent(message = "펀딩 시작 시점을 과거 시각으로 설정할 수 없습니다.")
         LocalDateTime fundingStartAt,
+
+        @FutureOrPresent(message = "펀딩 종료 시점을 과거 시각으로 설정할 수 없습니다.")
         LocalDateTime fundingEndAt,
+
+        @ValidEnum(enumClass = FundingCategory.class, message = "존재하지 않는 카테고리 입니다.")
         FundingCategory fundingCategory,
+
+        @ValidEnum(enumClass = FundingCategory.class, message = "유효하지 않은 펀딩 상태입니다.")
         FundingStatus fundingStatus
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
@@ -4,11 +4,13 @@ import com.prgrms.wadiz.domain.funding.FundingCategory;
 import com.prgrms.wadiz.domain.funding.FundingStatus;
 import com.prgrms.wadiz.domain.project.entity.Project;
 import com.prgrms.wadiz.domain.BaseEntity;
+import com.prgrms.wadiz.global.annotation.ValidEnum;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import javax.persistence.*;
+import javax.validation.constraints.Min;
 import java.time.LocalDateTime;
 
 @Entity
@@ -25,6 +27,7 @@ public class Funding extends BaseEntity {
     private Project project;
 
     @Column(nullable = false)
+    @Min(value = 0, message = "펀딩 모집 금액은 0이상의 정수만 허용됩니다.")
     private Integer fundingTargetAmount;
 
     @Column(nullable = false)
@@ -35,10 +38,12 @@ public class Funding extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @ValidEnum(enumClass = FundingCategory.class, message = "존재하지 않는 카테고리 입니다.")
     private FundingCategory fundingCategory;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @ValidEnum(enumClass = FundingCategory.class, message = "유효하지 않은 펀딩 상태입니다.")
     private FundingStatus fundingStatus;
 
     @Builder

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/annotation/EnumValidator.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/annotation/EnumValidator.java
@@ -1,0 +1,28 @@
+package com.prgrms.wadiz.global.annotation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/annotation/ValidEnum.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/annotation/ValidEnum.java
@@ -1,0 +1,18 @@
+package com.prgrms.wadiz.global.annotation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    String message() default "Invalid value. This is not permitted.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends java.lang.Enum<?>> enumClass();
+}


### PR DESCRIPTION
## 😇 use-case 배경 설명
Funding에 대한 정보를 등록 및 수정할 때 각 필드에 적합하지 않은 값을 받는지 검증해줘야한다.
Maker는 Project가 개설된 후로는 Funding에 대한 정보는 수정 및 삭제를 할 수 없다.

## 🍎 구현한 내용 설명
Request Body로 받는 내용을 bean validation으로 검증한다.
db에 쿼리가 날아가기 전 엔티티 필드에 bean validation으로 대해서 검증한다.
enum 필드를 검증할 수 있는 custom validation annotation을 만들어 사용한다.

## 📌리뷰어 리뷰 포인트
예외적인 값에 대해 검증을 잘 수행했는지 확인해주시면 좋겠습니다~!

## 👩‍💻테스트 <!--선택-->
![스크린샷 2023-09-07 오후 3 40 18](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/4d33e632-0100-4017-9432-1f4f16c20e34)

