### PR TITLE
[Feat] 주문 시스템 : 주문품목당 금액, 총 주문 금액 옵션 추가

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/dto/response/OrderResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/dto/response/OrderResponseDTO.java
@@ -14,6 +14,7 @@ public record OrderResponseDTO(
         String makerBrand,
         List<OrderRewardResponseDTO> orderRewardResponseDTOs,
         FundingCategory fundingCategory,
+        Integer totalOrderPrice,
         LocalDateTime createdAt,
         OrderStatus orderStatus
 ) {
@@ -23,6 +24,7 @@ public record OrderResponseDTO(
             String postTitle,
             String makerBrand,
             List<OrderRewardResponseDTO> orderRewardResponseDTOs,
+            Integer totalOrderPrice,
             OrderStatus orderStatus
     ){
         return OrderResponseDTO.builder()
@@ -30,6 +32,7 @@ public record OrderResponseDTO(
                 .postTitle(postTitle)
                 .makerBrand(makerBrand)
                 .orderRewardResponseDTOs(orderRewardResponseDTOs)
+                .totalOrderPrice(totalOrderPrice)
                 .orderStatus(orderStatus)
                 .build();
     }
@@ -37,11 +40,13 @@ public record OrderResponseDTO(
     public static OrderResponseDTO of(
             Long orderId,
             List<OrderRewardResponseDTO> orderRewardResponseDTOs,
+            Integer totalOrderPrice,
             OrderStatus orderStatus
     ){
         return OrderResponseDTO.builder()
                 .orderId(orderId)
                 .orderRewardResponseDTOs(orderRewardResponseDTOs)
+                .totalOrderPrice(totalOrderPrice)
                 .orderStatus(orderStatus)
                 .build();
     }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/entity/Order.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/entity/Order.java
@@ -36,6 +36,9 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderReward> orderRewards = new ArrayList<>();
 
+    @Column(nullable = false)
+    private int totalOrderPrice;
+
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
@@ -49,10 +52,13 @@ public class Order extends BaseEntity {
         this.orderStatus = OrderStatus.REQUESTED;
     }
 
-    //createOrder와 관련된 연관관계 편의 메서드
     public void addOrderReward(OrderReward orderReward) {
         orderRewards.add(orderReward);
         orderReward.changeOrder(this);
+    }
+
+    public void calculateTotalOrderPrice(OrderReward orderReward){
+        this.totalOrderPrice += orderReward.calculateOrderRewardPrice();
     }
 
     public void cancel() {

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
@@ -78,6 +78,7 @@ public class OrderService {
                 .build();
 
         orderRewards.forEach(order::addOrderReward);
+        orderRewards.forEach(order::calculateTotalOrderPrice);
 
         orderRepository.save(order);
     }
@@ -114,6 +115,7 @@ public class OrderService {
                 postTitle,
                 order.getProject().getMaker().getMakerBrand(),
                 orderRewardResponseDTOs,
+                order.getTotalOrderPrice(),
                 order.getOrderStatus()
         );
     }
@@ -186,6 +188,7 @@ public class OrderService {
                     return OrderResponseDTO.of(
                             order.getOrderId(),
                             orderRewardResponseDTOs,
+                            order.getTotalOrderPrice(),
                             order.getOrderStatus()
                     );
                 }).collect(Collectors.toList());

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/orderReward/dto/response/OrderRewardResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/orderReward/dto/response/OrderRewardResponseDTO.java
@@ -7,7 +7,8 @@ public record OrderRewardResponseDTO(
         String rewardName,
         String rewardDescription,
         Integer orderRewardPrice,
-        Integer orderRewardQuantity
+        Integer orderRewardQuantity,
+        Integer totalOrderRewardPrice
 ){
     public static OrderRewardResponseDTO of(
             String rewardName,
@@ -21,6 +22,7 @@ public record OrderRewardResponseDTO(
                 .rewardDescription(rewardDescription)
                 .orderRewardPrice(orderRewardPrice)
                 .orderRewardQuantity(orderRewardQuantity)
+                .totalOrderRewardPrice(orderRewardPrice * orderRewardQuantity)
                 .build();
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/orderReward/entity/OrderReward.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/orderReward/entity/OrderReward.java
@@ -54,6 +54,10 @@ public class OrderReward extends BaseEntity {
 
     }
 
+    public Integer calculateOrderRewardPrice(){
+        return this.orderRewardQuantity * this.orderRewardPrice;
+    }
+
     private Integer validatePositive(Integer orderRewardQuantity) {
         if(orderRewardQuantity < POSITIVE_ORDER_QUANTITY){
             throw new BaseException(ErrorCode.ORDER_COUNT_ERROR);
@@ -61,6 +65,5 @@ public class OrderReward extends BaseEntity {
 
         return orderRewardQuantity;
     }
-
 
 }

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/order/controller/OrderControllerTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/order/controller/OrderControllerTest.java
@@ -90,6 +90,7 @@ class OrderControllerTest {
                 "맛깔난 참죽 펀딩",
                 "씨제이",
                 orderRewardResponses,
+                10000*10,
                 OrderStatus.COMPLETED
         );
 
@@ -164,6 +165,7 @@ class OrderControllerTest {
         OrderResponseDTO orderRes = OrderResponseDTO.of(
                 1L,
                 orderRewardResponses,
+                10000*10,
                 OrderStatus.REQUESTED
         );
 

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/order/service/OrderServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/order/service/OrderServiceTest.java
@@ -208,6 +208,7 @@ class OrderServiceTest {
                 post.getPostTitle(),
                 maker.getMakerBrand(),
                 orderRewardResponseDTOS,
+                order.getTotalOrderPrice(),
                 OrderStatus.COMPLETED
         );
 
@@ -358,6 +359,7 @@ class OrderServiceTest {
         OrderResponseDTO orderRes = OrderResponseDTO.of(
                 order.getOrderId(),
                 orderRewardResponseDTOS,
+                order.getTotalOrderPrice(),
                 order.getOrderStatus()
         );
 


### PR DESCRIPTION
## 😇 use-case 배경 설명
<br>
주문 총 금액에 대한 연산 결과를 반환한다.

## 🍎 구현한 내용 설명
<br>
주문 당 품목은 데이터를 저장하지 않고, OrderRewardprice(결국 리워드 가격) * OrderRewardQuantity 로 연산 결과를 전달한다.
그리고 총 주문 금액은 Order에 필드를 만들어 저장하도록 했다. 
(어떤 정보가 어디 데이터에 저장되어야할 지 고민 한 결과, OrderReward에서는 단순 연산, Order에는 데이터 저장이 필요하겠다고 결론을 내림)
마찬가지로 해당 기능에서 파생되는 테스트 또한 구현을 통해 검증을 마침

## 📌리뷰어 리뷰 포인트
<br>

## 📝api 명세 <!--선택-->
<br>

## 👩‍💻테스트 <!--선택-->
<br>
