### PR TITLE
[Refactor,Test]WDZL-133 reward,maker,supporter test, 이메일 중복 체크, 상태

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/MakerStatus.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/MakerStatus.java
@@ -1,0 +1,8 @@
+package com.prgrms.wadiz.domain.maker;
+
+public enum MakerStatus {
+    REGISTERED,
+    SUSPEND,
+    EXPIRED,
+    UNREGISTERED
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/MakerServiceDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/MakerServiceDTO.java
@@ -11,10 +11,8 @@ import javax.validation.constraints.Size;
 @Builder
 public record MakerServiceDTO(
         Long makerId,
-        @Size(
-                min = 2,
-                message = "이름은 최소 2자 이상입니다."
-        )
+
+        @Size(min = 2, message = "이름은 최소 2자 이상입니다.")
         String makerName,
 
         @NotBlank(message = "브랜드를 입력해주세요.")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerCreateRequestDTO.java
@@ -9,10 +9,7 @@ import javax.validation.constraints.Size;
 
 @Builder
 public record MakerCreateRequestDTO(
-        @Size(
-                min = 2,
-                message = "이름은 최소 2자 이상입니다."
-        )
+        @Size(min = 2, message = "이름은 최소 2자 이상입니다.")
         String makerName,
 
         @NotBlank(message = "브랜드를 입력해주세요.")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/dto/request/MakerUpdateRequestDTO.java
@@ -9,10 +9,7 @@ import javax.validation.constraints.Size;
 
 @Builder
 public record MakerUpdateRequestDTO(
-        @Size(
-                min = 2,
-                message = "이름은 최소 2자 이상입니다."
-        )
+        @Size(min = 2, message = "이름은 최소 2자 이상입니다.")
         String makerName,
 
         @NotBlank(message = "브랜드를 입력해주세요.")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/entity/Maker.java
@@ -1,15 +1,16 @@
 package com.prgrms.wadiz.domain.maker.entity;
 
 import com.prgrms.wadiz.domain.BaseEntity;
+import com.prgrms.wadiz.domain.maker.MakerStatus;
+import com.prgrms.wadiz.domain.reward.RewardStatus.RewardStatus;
+import com.prgrms.wadiz.global.annotation.ValidEnum;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
@@ -36,7 +37,9 @@ public class Maker extends BaseEntity{
     private String makerEmail;
 
     @Column(nullable = false)
-    private boolean activated = Boolean.TRUE; // 활성화 여부 -> 삭제 시 FALSE
+    @Enumerated(EnumType.STRING)
+    @ValidEnum(enumClass = MakerStatus.class, message = "해당하는 메이커 상태가 존재하지 않습니다.")
+    private MakerStatus status = MakerStatus.REGISTERED;
 
 //    @Builder // 빌더가 이렇게도 생성될 수 있는지 알아보기 + 추가 설정으로
 //    public Maker(
@@ -87,8 +90,8 @@ public class Maker extends BaseEntity{
         this.makerEmail = makerEmail;
     }
 
-    public void deActivateMaker() {
-        this.activated = Boolean.FALSE;
+    public void unregisteredMaker() {
+        this.status = MakerStatus.UNREGISTERED;
     }
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
@@ -3,6 +3,8 @@ package com.prgrms.wadiz.domain.maker.respository;
 import com.prgrms.wadiz.domain.maker.entity.Maker;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MakerRepository extends JpaRepository<Maker, Long> {
+public interface MakerRepository extends JpaRepository<Maker, Long>{
     boolean existsByMakerEmail(String email);
+
+    boolean existsByMakerName(String name);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/respository/MakerRepository.java
@@ -4,4 +4,5 @@ import com.prgrms.wadiz.domain.maker.entity.Maker;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MakerRepository extends JpaRepository<Maker, Long> {
+    boolean existsByMakerEmail(String email);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
@@ -8,18 +8,26 @@ import com.prgrms.wadiz.domain.maker.entity.Maker;
 import com.prgrms.wadiz.domain.maker.respository.MakerRepository;
 import com.prgrms.wadiz.global.util.exception.BaseException;
 import com.prgrms.wadiz.global.util.exception.ErrorCode;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MakerService {
     private final MakerRepository makerRepository;
 
+    private JPAQueryFactory jpaQueryFactory;
+
     @Transactional
     public MakerResponseDTO signUpMaker(MakerCreateRequestDTO dto) {
+        checkDuplicateName(dto.makerName());
         checkDuplicateEmail(dto.makerEmail());
+
         Maker maker = Maker.builder()
                 .makerName(dto.makerName())
                 .makerBrand(dto.makerBrand())
@@ -71,6 +79,11 @@ public class MakerService {
     public void checkDuplicateEmail(String email) {
         if(makerRepository.existsByMakerEmail(email)){
             throw new BaseException((ErrorCode.DUPLICATED_EMAIL));
+        }
+    }
+    public void checkDuplicateName(String name) {
+        if(makerRepository.existsByMakerName(name)){
+            throw new BaseException((ErrorCode.DUPLICATED_NAME));
         }
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
@@ -52,6 +52,9 @@ public class MakerService {
             Long makerId,
             MakerUpdateRequestDTO dto
     ) {
+        checkDuplicateName(dto.makerName());
+        checkDuplicateEmail(dto.makerEmail());
+
         Maker maker = makerRepository.findById(makerId)
                 .orElseThrow(() -> new BaseException(ErrorCode.MAKER_NOT_FOUND));
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/maker/service/MakerService.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class MakerService {
@@ -21,6 +19,7 @@ public class MakerService {
 
     @Transactional
     public MakerResponseDTO signUpMaker(MakerCreateRequestDTO dto) {
+        checkDuplicateEmail(dto.makerEmail());
         Maker maker = Maker.builder()
                 .makerName(dto.makerName())
                 .makerBrand(dto.makerBrand())
@@ -66,6 +65,12 @@ public class MakerService {
         Maker maker = makerRepository.findById(makerId)
                 .orElseThrow(() -> new BaseException(ErrorCode.MAKER_NOT_FOUND));
 
-        maker.deActivateMaker();
+        maker.unregisteredMaker();
+    }
+
+    public void checkDuplicateEmail(String email) {
+        if(makerRepository.existsByMakerEmail(email)){
+            throw new BaseException((ErrorCode.DUPLICATED_EMAIL));
+        }
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/dto/request/RewardCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/dto/request/RewardCreateRequestDTO.java
@@ -22,12 +22,10 @@ public record RewardCreateRequestDTO(
         @Min(value = 10, message = "리워드 가격을 입력해주세요.")
         Integer rewardPrice,
 
-        @ValidEnum(enumClass = RewardType.class)
-//        @NotBlank(message = "리워드 타입을 입력해주세요.")
+        @ValidEnum(enumClass = RewardType.class, message = "리워드 타입을 입력해주세요.")
         RewardType rewardType,
 
-        @ValidEnum(enumClass = RewardStatus.class)
-//        @NotBlank(message = "리워드 상태를 입력해주세요.")
+        @ValidEnum(enumClass = RewardStatus.class, message = "리워드 타입을 입력해주세요.")
         RewardStatus rewardStatus
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/dto/request/RewardUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/dto/request/RewardUpdateRequestDTO.java
@@ -22,12 +22,10 @@ public record RewardUpdateRequestDTO(
         @Min(value = 10, message = "리워드 가격을 입력해주세요.")
         Integer rewardPrice,
 
-        @ValidEnum(enumClass = RewardType.class)
-//        @NotBlank(message = "리워드 타입을 입력해주세요.")
+        @ValidEnum(enumClass = RewardType.class, message = "리워드 타입을 입력해주세요.")
         RewardType rewardType,
 
-        @ValidEnum(enumClass = RewardStatus.class)
-//        @NotBlank(message = "리워드 상태를 입력해주세요.")
+        @ValidEnum(enumClass = RewardStatus.class, message = "리워드 상태를 입력해주세요.")
         RewardStatus rewardStatus
 ) {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/entity/Reward.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/entity/Reward.java
@@ -51,8 +51,7 @@ public class Reward extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ValidEnum(enumClass = RewardType.class)
-//    @NotBlank(message = "리워드 타입을 입력해주세요.")
+    @ValidEnum(enumClass = RewardType.class, message = "리워드 타입을 입력해주세요.")
     private RewardType rewardType;
 
     @Column(nullable = false)

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/entity/Reward.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/entity/Reward.java
@@ -57,8 +57,7 @@ public class Reward extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ValidEnum(enumClass = RewardStatus.class)
-//    @NotBlank(message = "리워드 상태를 입력해주세요.")
+    @ValidEnum(enumClass = RewardStatus.class, message = "리워드 상태를 입력해주세요.")
     private RewardStatus rewardStatus;
 
     @Column(nullable = false)
@@ -110,10 +109,6 @@ public class Reward extends BaseEntity {
 
     public void deletedStatus() {
         activated = Boolean.FALSE;
-    }
-
-    public void allocateProject(Project project) {
-        this.project = project;
     }
 
     public void addQuantity(Integer orderRewardQuantity) {

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/repository/RewardRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/repository/RewardRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface RewardRepository extends JpaRepository<Reward,Long> {
     @Query("SELECT r FROM Reward r WHERE r.project.projectId = :projectId")
-    Optional<List<Reward>> findByProjectId(Long projectId);
+    Optional<List<Reward>> findAllByProjectId(Long projectId);
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/repository/RewardRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/repository/RewardRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface RewardRepository extends JpaRepository<Reward,Long> {
     @Query("SELECT r FROM Reward r WHERE r.project.projectId = :projectId")
-    Optional<List<Reward>> findAllByProjectId(Long projectId);
+    Optional<List<Reward>> findByProjectId(Long projectId);
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/service/RewardService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/service/RewardService.java
@@ -88,12 +88,12 @@ public class RewardService {
     }
 
     public boolean isRewardsExist(Long projectId) {
-        Optional<List<Reward>> rewards = rewardRepository.findAllByProjectId(projectId);
+        Optional<List<Reward>> rewards = rewardRepository.findByProjectId(projectId);
         return rewards.isPresent();
     }
 
     public List<RewardResponseDTO> getRewardsByProjectId(Long projectId) {
-        List<Reward> rewards = rewardRepository.findAllByProjectId(projectId)
+        List<Reward> rewards = rewardRepository.findByProjectId(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.REWARD_NOT_FOUND));
 
         return rewards.stream().map(RewardResponseDTO::from).toList();

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/service/RewardService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/reward/service/RewardService.java
@@ -88,12 +88,12 @@ public class RewardService {
     }
 
     public boolean isRewardsExist(Long projectId) {
-        Optional<List<Reward>> rewards = rewardRepository.findByProjectId(projectId);
+        Optional<List<Reward>> rewards = rewardRepository.findAllByProjectId(projectId);
         return rewards.isPresent();
     }
 
     public List<RewardResponseDTO> getRewardsByProjectId(Long projectId) {
-        List<Reward> rewards = rewardRepository.findByProjectId(projectId)
+        List<Reward> rewards = rewardRepository.findAllByProjectId(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.REWARD_NOT_FOUND));
 
         return rewards.stream().map(RewardResponseDTO::from).toList();

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/SupporterStatus.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/SupporterStatus.java
@@ -1,0 +1,8 @@
+package com.prgrms.wadiz.domain.supporter;
+
+public enum SupporterStatus {
+    REGISTERED,
+    SUSPEND,
+    EXPIRED,
+    UNREGISTERED
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterCreateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterCreateRequestDTO.java
@@ -3,16 +3,11 @@ package com.prgrms.wadiz.domain.supporter.dto.request;
 import lombok.Builder;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Builder
 public record SupporterCreateRequestDTO(
-        @Size(
-                min = 2,
-                message = "이름은 최소 2자 이상입니다."
-        )
+        @Size(min = 2, message = "이름은 최소 2자 이상입니다.")
         String supporterName,
 
         @Email(message = "이메일 형식이 맞지 않습니다.")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterUpdateRequestDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/dto/request/SupporterUpdateRequestDTO.java
@@ -3,16 +3,11 @@ package com.prgrms.wadiz.domain.supporter.dto.request;
 import lombok.Builder;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Builder
 public record SupporterUpdateRequestDTO(
-        @Size(
-                min = 2,
-                message = "이름은 최소 2자 이상입니다."
-        )
+        @Size(min = 2, message = "이름은 최소 2자 이상입니다.")
         String supporterName,
 
         @Email(message = "이메일 형식이 맞지 않습니다.")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/entity/Supporter.java
@@ -2,6 +2,9 @@ package com.prgrms.wadiz.domain.supporter.entity;
 
 import com.prgrms.wadiz.domain.BaseEntity;
 
+import com.prgrms.wadiz.domain.maker.MakerStatus;
+import com.prgrms.wadiz.domain.supporter.SupporterStatus;
+import com.prgrms.wadiz.global.annotation.ValidEnum;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,8 +12,6 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Entity
@@ -29,10 +30,11 @@ public class Supporter extends BaseEntity {
     @Column(nullable = false)
     @Email(message = "이메일 정보를 입력해 주세요")
     private String supporterEmail;
-  
+
     @Column(nullable = false)
-    private boolean activated = Boolean.TRUE;
-    // 활성화 여부 -> 삭제 시 FALSE //// user 상태를 하나 만들기 (정지,탈퇴 등등)
+    @Enumerated(EnumType.STRING)
+    @ValidEnum(enumClass = SupporterStatus.class, message = "해당하는 서포터 상태가 존재하지 않습니다.")
+    private SupporterStatus status = SupporterStatus.REGISTERED;
 
     @Builder
     public Supporter(
@@ -47,11 +49,11 @@ public class Supporter extends BaseEntity {
     public Supporter(
             String name,
             String email,
-            Boolean isActivated
+            SupporterStatus supporterStatus
     ) {
         this.supporterName = name;
         this.supporterEmail = email;
-        this.activated = isActivated;
+        this.status = supporterStatus;
     }
 
     public void updateSupporter(String supporterName, String supporterEmail) {
@@ -59,7 +61,7 @@ public class Supporter extends BaseEntity {
         this.supporterEmail = supporterEmail;
     }
 
-    public void deActivateSupporter(){
-        this.activated = Boolean.FALSE;
+    public void unregisteredSupporter(){
+        this.status = SupporterStatus.UNREGISTERED;
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 public interface SupporterRepository extends JpaRepository<Supporter, Long> {
     boolean existsBySupporterEmail(String email);
+
+    boolean existsBySupporterName(String name);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/repository/SupporterRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 public interface SupporterRepository extends JpaRepository<Supporter, Long> {
+    boolean existsBySupporterEmail(String email);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
@@ -18,6 +18,7 @@ public class SupporterService {
 
     @Transactional
     public SupporterResponseDTO signUpSupporter(SupporterCreateRequestDTO dto) {
+        checkDuplicateEmail(dto.supporterEmail());
         Supporter supporter = Supporter.builder()
                 .supporterName(dto.supporterName())
                 .supporterEmail(dto.supporterEmail())
@@ -64,7 +65,13 @@ public class SupporterService {
         Supporter supporter = supporterRepository.findById(supporterId)
                 .orElseThrow(() -> new BaseException(ErrorCode.SUPPORTER_NOT_FOUND));
 
-        supporter.deActivateSupporter();
+        supporter.unregisteredSupporter();
+    }
+
+    public void checkDuplicateEmail(String email) {
+        if(supporterRepository.existsBySupporterEmail(email)){
+            throw new BaseException((ErrorCode.DUPLICATED_EMAIL));
+        }
     }
 
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
@@ -19,6 +19,8 @@ public class SupporterService {
     @Transactional
     public SupporterResponseDTO signUpSupporter(SupporterCreateRequestDTO dto) {
         checkDuplicateEmail(dto.supporterEmail());
+        checkDuplicateName(dto.supporterName());
+
         Supporter supporter = Supporter.builder()
                 .supporterName(dto.supporterName())
                 .supporterEmail(dto.supporterEmail())
@@ -46,6 +48,10 @@ public class SupporterService {
             Long supporterId,
             SupporterUpdateRequestDTO dto
     ) {
+
+        checkDuplicateEmail(dto.supporterEmail());
+        checkDuplicateName(dto.supporterName());
+
         Supporter supporter = supporterRepository.findById(supporterId)
                 .orElseThrow(() -> new BaseException(ErrorCode.SUPPORTER_NOT_FOUND));
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/supporter/service/SupporterService.java
@@ -74,4 +74,10 @@ public class SupporterService {
         }
     }
 
+    public void checkDuplicateName(String name) {
+        if(supporterRepository.existsBySupporterName(name)){
+            throw new BaseException((ErrorCode.DUPLICATED_NAME));
+        }
+    }
+
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 
     POST_NOT_FOUND(-2000, "게시글 정보를 찾을 수 없습니다."),
     ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." ),
-증    NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다."),
+    NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다."),
     DUPLICATED_EMAIL(-2003, "중복된 이메일이 이미 존재합니다.");
 
     private int code;

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     POST_NOT_FOUND(-2000, "게시글 정보를 찾을 수 없습니다."),
     ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." ),
     NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다."),
-    DUPLICATED_EMAIL(-2003, "중복된 이메일이 이미 존재합니다.");
+    DUPLICATED_EMAIL(-2003, "중복된 이메일이 이미 존재합니다."),
+    DUPLICATED_NAME(-2004, "중복된 이름이 이미 존재합니다." );
 
     private int code;
     private String errorMessage;

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
 
     POST_NOT_FOUND(-2000, "게시글 정보를 찾을 수 없습니다."),
     ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." ),
-    NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다.");
+증    NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다."),
+    DUPLICATED_EMAIL(-2003, "중복된 이메일이 이미 존재합니다.");
 
     private int code;
     private String errorMessage;

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/reward/controller/RewardControllerTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/reward/controller/RewardControllerTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(RewardController.class)
 class RewardControllerTest {
 
     @MockBean

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/reward/service/RewardServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/reward/service/RewardServiceTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.wadiz.domain.reward.service;
 
 import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
+import com.prgrms.wadiz.domain.project.entity.Project;
 import com.prgrms.wadiz.domain.reward.RewardStatus.RewardStatus;
 import com.prgrms.wadiz.domain.reward.RewardType.RewardType;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardCreateRequestDTO;
@@ -49,8 +50,8 @@ class RewardServiceTest {
         when(rewardRepository.save(any(Reward.class))).then(AdditionalAnswers.returnsFirstArg());
 
         //when
-        Long rewardId = rewardService.createReward(projectServiceDTO, createRequestDTO);
-        Optional<Reward> savedReward = rewardRepository.findById(rewardId);
+        RewardResponseDTO reward = rewardService.createReward(projectServiceDTO, createRequestDTO);
+        Optional<Reward> savedReward = rewardRepository.findById(reward.rewardId());
 
         //then
         assertThat(savedReward).isNotNull();
@@ -59,32 +60,20 @@ class RewardServiceTest {
     @Test
     @DisplayName("[성공] 리워드 수정 테스트")
     void rewardUpdateTest() {
-        ProjectServiceDTO projectServiceDTO = ProjectServiceDTO.builder()
+        Project readyProject = Project.builder()
                 .projectId(1L)
                 .build();
 
-        RewardCreateRequestDTO createRequestDTO = RewardCreateRequestDTO.builder()
-                .rewardName("test")
-                .rewardDescription("test")
-                .rewardQuantity(100)
-                .rewardPrice(100)
-                .rewardType(RewardType.SINGLE)
-                .rewardStatus(RewardStatus.IN_STOCK)
-                .build();
-
-        when(rewardRepository.save(any(Reward.class))).then(AdditionalAnswers.returnsFirstArg());
-
-        Long rewardId = rewardService.createReward(projectServiceDTO, createRequestDTO);
-
         Reward reward = Reward.builder()
                 .rewardName("test")
+                .project(readyProject)
                 .rewardDescription("test")
                 .rewardQuantity(100)
                 .rewardPrice(100)
                 .rewardType(RewardType.SINGLE)
                 .build();
 
-        when(rewardRepository.findById(rewardId)).thenReturn(Optional.of(reward));
+        when(rewardRepository.findById(reward.getRewardId())).thenReturn(Optional.of(reward));
 
         RewardUpdateRequestDTO updateRequestDTO = RewardUpdateRequestDTO.builder()
                 .rewardName("update")
@@ -96,7 +85,11 @@ class RewardServiceTest {
                 .build();
 
         //when
-        RewardResponseDTO updateReward = rewardService.updateReward(1L, rewardId, updateRequestDTO);
+        RewardResponseDTO updateReward = rewardService.updateReward(
+                1L,
+                reward.getRewardId(),
+                updateRequestDTO
+        );
 
         //then
         assertThat(updateReward.rewardName()).isEqualTo("update");
@@ -111,34 +104,24 @@ class RewardServiceTest {
     @DisplayName("[성공] 리워드 soft-delete 테스트")
     void deleteRewardTest() {
         //given
-        ProjectServiceDTO projectServiceDTO = ProjectServiceDTO.builder().build();
-
-        RewardCreateRequestDTO createRequestDTO = RewardCreateRequestDTO.builder()
-                .rewardName("test")
-                .rewardDescription("test")
-                .rewardQuantity(100)
-                .rewardPrice(100)
-                .rewardType(RewardType.SINGLE)
-                .rewardStatus(RewardStatus.IN_STOCK)
+        Project readyProject = Project.builder()
+                .projectId(1L)
                 .build();
-
-        when(rewardRepository.save(any(Reward.class))).then(AdditionalAnswers.returnsFirstArg());
-
-        Long rewardId = rewardService.createReward(projectServiceDTO, createRequestDTO);
 
         Reward reward = Reward.builder()
                 .rewardName("test")
+                .project(readyProject)
                 .rewardDescription("test")
                 .rewardQuantity(100)
                 .rewardPrice(100)
                 .rewardType(RewardType.SINGLE)
                 .build();
 
-        when(rewardRepository.findById(rewardId)).thenReturn(Optional.of(reward));
+        when(rewardRepository.findById(reward.getRewardId())).thenReturn(Optional.of(reward));
 
         //when
-        rewardService.deleteReward(rewardId, rewardId);
-        Optional<Reward> findReward = rewardRepository.findById(rewardId);
+        rewardService.deleteReward(readyProject.getProjectId(),reward.getRewardId());
+        Optional<Reward> findReward = rewardRepository.findById(reward.getRewardId());
 
         //then
         assertThat(findReward.get().getActivated()).isEqualTo(Boolean.FALSE);


### PR DESCRIPTION
## 🍎 구현한 내용 설명
RewardServiceTest,
Maker, Supporter : Status enum 필드 추가, 이메일 중복 체크를 통한 중복 회원가입 예외

## 📌리뷰어 리뷰 포인트
<br>
이메일 중복 체크 검증, enum 클래스 명칭 등

## 👩‍💻테스트 <!--선택-->
<br>

### MakerServiceTest
![image](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/93516595/d9aebfaf-f01c-4559-ba5c-6e7dd32aac55)

### SupporterServiceTest
![image](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/93516595/6d050a79-29f2-4452-a9b7-a8ef2734a094)

### RewardServiceTest
![image](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/93516595/626047f0-15b5-460d-9461-5bfaa5196c84)
