### PR TITLE
[Feat] Project 시스템 : 프로젝트 다건 조회 커서 페이징 구현

### DIFF
--- a/wadiz/build.gradle
+++ b/wadiz/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.14'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.prgrms'
@@ -27,12 +28,35 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
+	// querydsl 추가
+	implementation "com.querydsl:querydsl-jpa:5.0.0"
+	implementation "com.querydsl:querydsl-apt:5.0.0"
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+}
+
+// Qtype 생성 경로
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/post/service/PostService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/post/service/PostService.java
@@ -42,10 +42,6 @@ public class PostService {
         Post post = postRepository.findByProjectId(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.POST_NOT_FOUND));
 
-        if (!isProjectBeforeSetUp(post.getProject())) {
-            throw new BaseException(ErrorCode.PROJECT_ACCESS_DENY);
-        }
-
         return PostResponseDTO.from(post);
     }
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/condition/ProjectSearchCondition.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/condition/ProjectSearchCondition.java
@@ -1,0 +1,5 @@
+package com.prgrms.wadiz.domain.project.condition;
+
+public enum ProjectSearchCondition {
+    OPEN, CLOSE
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -7,6 +7,7 @@ import com.prgrms.wadiz.domain.funding.dto.request.FundingCreateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.request.FundingUpdateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectPageResponseDTO;
 import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
 import com.prgrms.wadiz.domain.project.service.ProjectUseCase;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardCreateRequestDTO;
@@ -55,9 +56,9 @@ public class ProjectController {
             @RequestParam(required = false) Long cursorId,
             @RequestParam int size
     ) {
-        Page<ProjectSummaryResponseDTO> projects = projectUseCase.getProjects(cursorId, size);
+        ProjectSummaryResponseDTO projectSummaryRes = projectUseCase.getProjects(cursorId, size);
 
-        return ResponseEntity.ok(ResponseFactory.getSingleResult(projects));
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(projectSummaryRes));
     }
 
     /**

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/controller/ProjectController.java
@@ -7,6 +7,7 @@ import com.prgrms.wadiz.domain.funding.dto.request.FundingCreateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.request.FundingUpdateRequestDTO;
 import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
 import com.prgrms.wadiz.domain.project.service.ProjectUseCase;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardCreateRequestDTO;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardUpdateRequestDTO;
@@ -14,6 +15,7 @@ import com.prgrms.wadiz.domain.reward.dto.response.RewardResponseDTO;
 import com.prgrms.wadiz.global.util.resTemplate.ResponseFactory;
 import com.prgrms.wadiz.global.util.resTemplate.ResponseTemplate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -46,6 +48,16 @@ public class ProjectController {
         ProjectResponseDTO projectResponseDTO = projectUseCase.getProject(projectId);
 
         return ResponseEntity.ok(ResponseFactory.getSingleResult(projectResponseDTO));
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseTemplate> getProjects(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam int size
+    ) {
+        Page<ProjectSummaryResponseDTO> projects = projectUseCase.getProjects(cursorId, size);
+
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(projects));
     }
 
     /**

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectPageResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectPageResponseDTO.java
@@ -1,0 +1,26 @@
+package com.prgrms.wadiz.domain.project.dto.response;
+
+import com.prgrms.wadiz.domain.project.entity.Project;
+import lombok.Builder;
+
+@Builder
+public record ProjectPageResponseDTO(
+        Long projectId,
+        String title,
+        String thumbNailImage,
+        String makerBrand
+) {
+    public static ProjectPageResponseDTO of(
+            Long projectId,
+            String title,
+            String thumbNailImage,
+            String makerBrand
+    ) {
+       return ProjectPageResponseDTO.builder()
+               .projectId(projectId)
+               .title(title)
+               .thumbNailImage(thumbNailImage)
+               .makerBrand(makerBrand)
+               .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectResponseDTO.java
@@ -3,6 +3,7 @@ package com.prgrms.wadiz.domain.project.dto.response;
 import com.prgrms.wadiz.domain.funding.dto.response.FundingResponseDTO;
 import com.prgrms.wadiz.domain.maker.dto.response.MakerResponseDTO;
 import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
+import com.prgrms.wadiz.domain.project.entity.Project;
 import com.prgrms.wadiz.domain.reward.dto.response.RewardResponseDTO;
 import lombok.Builder;
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectSummaryResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectSummaryResponseDTO.java
@@ -1,18 +1,24 @@
 package com.prgrms.wadiz.domain.project.dto.response;
 
-import com.prgrms.wadiz.domain.project.entity.Project;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record ProjectSummaryResponseDTO(
-        Long projectId,
-        String title,
-        String thumbNailImage,
-        String makerBrand
+        List<ProjectPageResponseDTO> contents,
+        int numberOfElements,
+        Long nextCursor
 ) {
-    public static ProjectSummaryResponseDTO from(Project project) {
+    public static ProjectSummaryResponseDTO of(
+            List<ProjectPageResponseDTO> projectPages,
+            int numberOfElements,
+            Long nextCursor
+    ) {
         return ProjectSummaryResponseDTO.builder()
-                .projectId(project.getProjectId())
+                .contents(projectPages)
+                .numberOfElements(numberOfElements)
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectSummaryResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectSummaryResponseDTO.java
@@ -1,0 +1,18 @@
+package com.prgrms.wadiz.domain.project.dto.response;
+
+import com.prgrms.wadiz.domain.project.entity.Project;
+import lombok.Builder;
+
+@Builder
+public record ProjectSummaryResponseDTO(
+        Long projectId,
+        String title,
+        String thumbNailImage,
+        String makerBrand
+) {
+    public static ProjectSummaryResponseDTO from(Project project) {
+        return ProjectSummaryResponseDTO.builder()
+                .projectId(project.getProjectId())
+                .build();
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepository.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepository.java
@@ -3,5 +3,5 @@ package com.prgrms.wadiz.domain.project.repository;
 import com.prgrms.wadiz.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project,Long> {
+public interface ProjectRepository extends JpaRepository<Project,Long>, ProjectRepositoryCustom {
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryCustom.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.prgrms.wadiz.domain.project.repository;
+
+import com.prgrms.wadiz.domain.project.condition.ProjectSearchCondition;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProjectRepositoryCustom {
+    Page<ProjectSummaryResponseDTO> findAllByCondition(Long cursorId, ProjectSearchCondition projectSearchCondition, Pageable pageable);
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryCustom.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.prgrms.wadiz.domain.project.repository;
 
 import com.prgrms.wadiz.domain.project.condition.ProjectSearchCondition;
-import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
+import com.prgrms.wadiz.domain.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProjectRepositoryCustom {
-    Page<ProjectSummaryResponseDTO> findAllByCondition(Long cursorId, ProjectSearchCondition projectSearchCondition, Pageable pageable);
+    Page<Project> findAllByCondition(Long cursorId, ProjectSearchCondition projectSearchCondition, Pageable pageable);
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryImpl.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryImpl.java
@@ -1,8 +1,6 @@
 package com.prgrms.wadiz.domain.project.repository;
 
 import com.prgrms.wadiz.domain.project.condition.ProjectSearchCondition;
-import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
-import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
 import com.prgrms.wadiz.domain.project.entity.Project;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,22 +18,26 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<ProjectSummaryResponseDTO> findAllByCondition(Long cursorId, ProjectSearchCondition projectSearchCondition, Pageable pageable) {
+    public Page<Project> findAllByCondition(
+            Long cursorId,
+            ProjectSearchCondition projectSearchCondition,
+            Pageable pageable
+    ) {
         List<Project> findBoards = jpaQueryFactory.selectFrom(project)
                 .where(cursorId(cursorId))
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        List<ProjectSummaryResponseDTO> responseDTOS = findBoards.stream()
-                .map(ProjectSummaryResponseDTO::from)
-                .toList();
-
-        return PageableExecutionUtils.getPage(responseDTOS, pageable, responseDTOS::size);
+        return PageableExecutionUtils.getPage(
+                findBoards,
+                pageable,
+                findBoards::size
+        );
     }
 
     private BooleanExpression cursorId(Long cursorId){
         if (cursorId == null) {
-            return null;
+            return project.projectId.gt(0L);
         }
 
         return project.projectId.gt(cursorId);

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryImpl.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/repository/ProjectRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.prgrms.wadiz.domain.project.repository;
+
+import com.prgrms.wadiz.domain.project.condition.ProjectSearchCondition;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectResponseDTO;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
+import com.prgrms.wadiz.domain.project.entity.Project;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.prgrms.wadiz.domain.project.entity.QProject.project;
+
+@RequiredArgsConstructor
+public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ProjectSummaryResponseDTO> findAllByCondition(Long cursorId, ProjectSearchCondition projectSearchCondition, Pageable pageable) {
+        List<Project> findBoards = jpaQueryFactory.selectFrom(project)
+                .where(cursorId(cursorId))
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<ProjectSummaryResponseDTO> responseDTOS = findBoards.stream()
+                .map(ProjectSummaryResponseDTO::from)
+                .toList();
+
+        return PageableExecutionUtils.getPage(responseDTOS, pageable, responseDTOS::size);
+    }
+
+    private BooleanExpression cursorId(Long cursorId){
+        if (cursorId == null) {
+            return null;
+        }
+
+        return project.projectId.gt(cursorId);
+    }
+}

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectUseCase.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectUseCase.java
@@ -11,7 +11,9 @@ import com.prgrms.wadiz.domain.maker.service.MakerService;
 import com.prgrms.wadiz.domain.post.dto.request.PostCreateRequestDTO;
 import com.prgrms.wadiz.domain.post.dto.request.PostUpdateRequestDTO;
 import com.prgrms.wadiz.domain.post.dto.response.PostResponseDTO;
+import com.prgrms.wadiz.domain.project.condition.ProjectSearchCondition;
 import com.prgrms.wadiz.domain.project.dto.ProjectServiceDTO;
+import com.prgrms.wadiz.domain.project.dto.response.ProjectSummaryResponseDTO;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardCreateRequestDTO;
 import com.prgrms.wadiz.domain.reward.dto.request.RewardUpdateRequestDTO;
 import com.prgrms.wadiz.domain.reward.dto.response.RewardResponseDTO;
@@ -23,6 +25,8 @@ import com.prgrms.wadiz.domain.project.entity.Project;
 import com.prgrms.wadiz.domain.project.repository.ProjectRepository;
 import com.prgrms.wadiz.global.util.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -194,4 +198,12 @@ public class ProjectUseCase {
         return rewardService.getReward(projectId, rewardId);
     }
 
+    @Transactional(readOnly = true)
+    public Page<ProjectSummaryResponseDTO> getProjects(Long cursorId, int size) {
+        return projectRepository.findAllByCondition(
+                cursorId,
+                ProjectSearchCondition.OPEN,
+                PageRequest.of(0, size)
+        );
+    }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/global/config/QueryDSLConfig.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.prgrms.wadiz.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDSLConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 😇 use-case 배경 설명
<br>
사용자가 무한 스크롤 기능으로 프로젝트를 조회할 수 있도록 커서 페이징으로 구현한다.

## 🍎 구현한 내용 설명

-  querydsl을 활용하여 커서 페이징을 위한 레포지토리를 만들고 동적 쿼리를 작성한다.
- page반환값에서 필요한 정보만을 골라서 반환한다.
- 조회한 페이지 중 가장 마지막 cursorId값을 전달하고, 마지막 cursor id가 실제로 저장된 값 중 가장 마지막인 경우, 다음으로 조회한 데이터는 빈값과 null 커서 id를 전달한다.

## 📌리뷰어 리뷰 포인트
<br>

## 📝api 명세 <!--선택-->
<br>

## 👩‍💻테스트 <!--선택-->
<br>
