### PR TITLE
[Feat] Funding 시스템: 펀딩 날짜에 대한 검증

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/global/util/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(-2001,"주문 정보를 찾을 수 없습니다." ),
     NOT_MATCH(-2002, "리워드의 프로젝트 아이디에 매치할 수 없습니다."),
     DUPLICATED_EMAIL(-2003, "중복된 이메일이 이미 존재합니다."),
-    DUPLICATED_NAME(-2004, "중복된 이름이 이미 존재합니다." );
+    DUPLICATED_NAME(-2004, "중복된 이름이 이미 존재합니다." ),
+    INVALID_FUNDING_DURATION(-1000, "펀딩 종료 시간이 펀딩 시작 시간보다 앞설 수 없습니다.");
 
     private int code;
     private String errorMessage;

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/funding/service/FundingServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/funding/service/FundingServiceTest.java
@@ -203,4 +203,51 @@ class FundingServiceTest {
                 .isInstanceOf(BaseException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_ACCESS_DENY);
     }
+
+    @Test
+    @DisplayName("[예외] Funding 정보를 생성할 때, 종료 시각이 시작 시각보다 앞선 경우 예외가 발생한다.")
+    void createFundingWithWrongTime() {
+        // given
+        ProjectServiceDTO projectServiceDTO = ProjectServiceDTO.builder().build();
+
+        LocalDateTime wrongStartAt = LocalDateTime.now().plusWeeks(2L);
+        LocalDateTime wrongEndAt = LocalDateTime.now();
+
+        FundingCreateRequestDTO wrongRequestDTO = FundingCreateRequestDTO.builder()
+                .fundingTargetAmount(1_000_000)
+                .fundingCategory(FundingCategory.FOOD)
+                .fundingStartAt(wrongStartAt)
+                .fundingEndAt(wrongEndAt)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> fundingService.createFunding(projectServiceDTO, wrongRequestDTO))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FUNDING_DURATION);
+    }
+
+    @Test
+    @DisplayName("[예외] Funding 정보를 수정할 때, 종료 시각이 시작 시각보다 앞선 경우 예외가 발생한다.")
+    void updateFundingWithWrongTime() {
+        // given
+        Long projectId = 1L;
+
+        LocalDateTime wrongStartAt = LocalDateTime.now().plusWeeks(2L);
+        LocalDateTime wrongEndAt = LocalDateTime.now();
+
+        FundingUpdateRequestDTO wrongRequestDTO = new FundingUpdateRequestDTO(
+                500_000,
+                wrongStartAt,
+                wrongEndAt,
+                FundingCategory.FASHION,
+                FundingStatus.OPEN
+        );
+
+        // when
+        // then
+        assertThatThrownBy(() -> fundingService.updateFunding(projectId, wrongRequestDTO))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FUNDING_DURATION);
+    }
 }


### PR DESCRIPTION
## 😇 use-case 배경 설명
펀딩 정보를 게시 및 수정하는 상황에서 펀딩 종료 시점이 펀딩 시작 시점보다 앞설 수 없다.
<br>

## 🍎 구현한 내용 설명
LocalDateTime의 메소드를 활용하여 
Funding Service Layer에서 요청으로 들어오는 시작 시간과 종료 시간의 선후 관계에 대해 검증해주었습니다.
<br>

## 📌리뷰어 리뷰 포인트
검증에 대한 부분을 위주로 봐주시면 될 것 같습니다~!
<br>

## 👩‍💻테스트 <!--선택-->
![스크린샷 2023-09-11 오후 5 25 25](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/c20c5209-3300-4d3a-a37b-26938460f665)
![스크린샷 2023-09-11 오후 5 25 39](https://github.com/prgrms-be-devcourse/BE-04-WadizLove/assets/98803599/765d04ef-54a7-4bcc-a923-15ff544daa19)