### PR TITLE
[Feat] funding 참여자수, 달성률, 달성 금액, 달성 여부 기능 구현 order와 연계

### DIFF
--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/dto/response/FundingResponseDTO.java
@@ -13,6 +13,10 @@ public record FundingResponseDTO(
         Integer fundingTargetAmount,
         LocalDateTime fundingStartAt,
         LocalDateTime fundingEndAt,
+        int fundingParticipants,
+        int fundingAmount,
+        int fundingSuccessRate,
+        boolean fundingSuccess,
         FundingCategory fundingCategory,
         FundingStatus fundingStatus
 ) {
@@ -22,6 +26,10 @@ public record FundingResponseDTO(
                 .fundingTargetAmount(funding.getFundingTargetAmount())
                 .fundingStartAt(funding.getFundingStartAt())
                 .fundingEndAt(funding.getFundingEndAt())
+                .fundingParticipants(funding.getFundingParticipants())
+                .fundingAmount(funding.getFundingAmount())
+                .fundingSuccessRate(funding.getFundingSuccessRate())
+                .fundingSuccess(funding.isFundingSuccess())
                 .fundingCategory(funding.getFundingCategory())
                 .fundingStatus(funding.getFundingStatus())
                 .build();

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
@@ -37,6 +37,18 @@ public class Funding extends BaseEntity {
     private LocalDateTime fundingEndAt;
 
     @Column(nullable = false)
+    private int fundingParticipants;
+
+    @Column(nullable = false)
+    private int fundingAmount;
+
+    @Column(nullable = false) //수정 : booleantype은 tinyint로 0 1로 구분되어 저장된다.
+    private int fundingSuccessRate;
+
+    @Column(nullable = false)
+    private boolean fundingSuccess = Boolean.FALSE;
+
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     @ValidEnum(enumClass = FundingCategory.class, message = "존재하지 않는 카테고리 입니다.")
     private FundingCategory fundingCategory;
@@ -45,18 +57,6 @@ public class Funding extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @ValidEnum(enumClass = FundingStatus.class, message = "유효하지 않은 펀딩 상태입니다.")
     private FundingStatus fundingStatus;
-
-    @Column(nullable = false)
-    private Integer fundingParticipants;
-
-    @Column(nullable = false)
-    private Integer fundingAmount;
-
-    @Column(nullable = false)
-    private Integer fundingSuccessRate;
-
-    @Column(nullable = false)
-    private Boolean fundingSuccess;
 
     @Builder
     public Funding(
@@ -88,16 +88,21 @@ public class Funding extends BaseEntity {
         this.fundingStatus = fundingStatus;
     }
 
-    public void updateOrderInfo(int totalOrderPrice) { // 보류
+    public void addOrderInfo(int totalOrderPrice) {
         this.fundingAmount += totalOrderPrice;
         this.fundingParticipants += 1;
-        this.fundingSuccessRate = (int) Math.round((double) this.fundingAmount / this.fundingTargetAmount);
+        this.fundingSuccessRate = (int) Math.round((this.fundingAmount /(double) this.fundingTargetAmount) * 100);
+        validateFundingSuccess(this.fundingAmount , this.fundingTargetAmount);
+    }
+
+    public void removeOrderInfo(int totalOrderPrice) {
+        this.fundingAmount -= totalOrderPrice;
+        this.fundingParticipants -= 1;
+        this.fundingSuccessRate = (int) Math.round((this.fundingAmount /(double) this.fundingTargetAmount) * 100);
         validateFundingSuccess(this.fundingAmount , this.fundingTargetAmount);
     }
 
     private void validateFundingSuccess(Integer fundingAmount, Integer fundingTargetAmount) {
-        if (fundingAmount >= fundingTargetAmount){
-            this.fundingSuccess = Boolean.TRUE;
-        }
+        this.fundingSuccess = (fundingAmount >= fundingTargetAmount) ? Boolean.TRUE : Boolean.FALSE;
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/funding/entity/Funding.java
@@ -46,6 +46,18 @@ public class Funding extends BaseEntity {
     @ValidEnum(enumClass = FundingStatus.class, message = "유효하지 않은 펀딩 상태입니다.")
     private FundingStatus fundingStatus;
 
+    @Column(nullable = false)
+    private Integer fundingParticipants;
+
+    @Column(nullable = false)
+    private Integer fundingAmount;
+
+    @Column(nullable = false)
+    private Integer fundingSuccessRate;
+
+    @Column(nullable = false)
+    private Boolean fundingSuccess;
+
     @Builder
     public Funding(
             Project project,
@@ -74,5 +86,18 @@ public class Funding extends BaseEntity {
         this.fundingEndAt = fundingEndAt;
         this.fundingCategory = fundingCategory;
         this.fundingStatus = fundingStatus;
+    }
+
+    public void updateOrderInfo(int totalOrderPrice) { // 보류
+        this.fundingAmount += totalOrderPrice;
+        this.fundingParticipants += 1;
+        this.fundingSuccessRate = (int) Math.round((double) this.fundingAmount / this.fundingTargetAmount);
+        validateFundingSuccess(this.fundingAmount , this.fundingTargetAmount);
+    }
+
+    private void validateFundingSuccess(Integer fundingAmount, Integer fundingTargetAmount) {
+        if (fundingAmount >= fundingTargetAmount){
+            this.fundingSuccess = Boolean.TRUE;
+        }
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/controller/OrderController.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/controller/OrderController.java
@@ -27,9 +27,9 @@ public class OrderController {
             @PathVariable Long supporterId,
             @RequestBody @Valid OrderCreateRequestDTO orderCreateRequestDto
     ){
-        OrderResponseDTO orderREsponseDTO = orderService.createOrder(supporterId, orderCreateRequestDto);
+        OrderResponseDTO orderResponseDTO = orderService.createOrder(supporterId, orderCreateRequestDto);
 
-        return ResponseEntity.ok(ResponseFactory.getSingleResult(orderREsponseDTO));
+        return ResponseEntity.ok(ResponseFactory.getSingleResult(orderResponseDTO));
     }
 
     @PutMapping("{orderId}/supporters/{supporterId}")

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/entity/Order.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/entity/Order.java
@@ -38,7 +38,7 @@ public class Order extends BaseEntity {
     private List<OrderReward> orderRewards = new ArrayList<>();
 
     @Column(nullable = false)
-    private Integer totalOrderPrice;
+    private int totalOrderPrice;
   
     @ValidEnum(enumClass = OrderStatus.class, message = "존재하지 않는 상태입니다.")
 

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.prgrms.wadiz.domain.order.service;
 
 import com.prgrms.wadiz.domain.funding.FundingCategory;
+import com.prgrms.wadiz.domain.funding.entity.Funding;
 import com.prgrms.wadiz.domain.funding.repository.FundingRepository;
 import com.prgrms.wadiz.domain.order.dto.request.OrderCreateRequestDTO;
 import com.prgrms.wadiz.domain.order.dto.response.OrderResponseDTO;
@@ -45,7 +46,7 @@ public class OrderService {
                 .orElseThrow(() -> {
                     log.error("Supporter {} is not found", supporterId);
 
-                    return new BaseException(ErrorCode.UNKNOWN);
+                    throw new BaseException(ErrorCode.UNKNOWN);
                 });
 
         List<OrderReward> orderRewards = orderCreateRequestDto.orderRewards().stream()
@@ -54,7 +55,7 @@ public class OrderService {
                             .orElseThrow(() -> {
                                 log.error("reward is not found");
 
-                                return new BaseException(ErrorCode.UNKNOWN);
+                                throw new BaseException(ErrorCode.UNKNOWN);
                             });
 
                     Integer orderQuantity = orderRewardRequest.orderQuantity();
@@ -81,6 +82,14 @@ public class OrderService {
         orderRewards.forEach(order::calculateTotalOrderPrice);
 
         orderRepository.save(order);
+
+        // 보류!
+        Funding funding = fundingRepository.findByProjectId(project.getProjectId())
+                .orElseThrow(() -> {
+                    throw new BaseException(ErrorCode.PROJECT_NOT_FOUND);
+                });
+
+        funding.updateOrderInfo(order.getTotalOrderPrice());
     }
 
     @Transactional(readOnly = true)

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectPageResponseDTO.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/dto/response/ProjectPageResponseDTO.java
@@ -8,19 +8,25 @@ public record ProjectPageResponseDTO(
         Long projectId,
         String title,
         String thumbNailImage,
-        String makerBrand
+        String makerBrand,
+        int fundingSuccessRate,
+        int fundingAmount
 ) {
     public static ProjectPageResponseDTO of(
             Long projectId,
             String title,
             String thumbNailImage,
-            String makerBrand
+            String makerBrand,
+            int fundingSuccessRate,
+            int fundingAmount
     ) {
        return ProjectPageResponseDTO.builder()
                .projectId(projectId)
                .title(title)
                .thumbNailImage(thumbNailImage)
                .makerBrand(makerBrand)
+               .fundingSuccessRate(fundingSuccessRate)
+               .fundingAmount(fundingAmount)
                .build();
     }
 }

--- a/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectUseCase.java
+++ b/wadiz/src/main/java/com/prgrms/wadiz/domain/project/service/ProjectUseCase.java
@@ -211,12 +211,15 @@ public class ProjectUseCase {
                 .map(project -> {
                     Long projectId = project.getProjectId();
                     PostResponseDTO postResponseDTO = postService.getPostByProjectId(projectId);
+                    FundingResponseDTO fundingResponseDTO = fundingService.getFundingByProjectId(projectId);
 
                     return ProjectPageResponseDTO.of(
                             projectId,
                             postResponseDTO.postTitle(),
                             postResponseDTO.postThumbNailImage(),
-                            project.getMaker().getMakerBrand()
+                            project.getMaker().getMakerBrand(),
+                            fundingResponseDTO.fundingSuccessRate(),
+                            fundingResponseDTO.fundingAmount()
                     );
                 })
                 .toList();

--- a/wadiz/src/test/java/com/prgrms/wadiz/domain/order/service/OrderServiceTest.java
+++ b/wadiz/src/test/java/com/prgrms/wadiz/domain/order/service/OrderServiceTest.java
@@ -142,7 +142,8 @@ class OrderServiceTest {
         given(rewardRepository.findById(anyLong())).willReturn(Optional.of(reward));
 
         //when, then
-        assertThatThrownBy(() ->orderService.createOrder(supporter.getSupporterId(), orderCreateReq)).isInstanceOf(BaseException.class);
+        assertThatThrownBy(() ->orderService.createOrder(supporter.getSupporterId(), orderCreateReq))
+                .isInstanceOf(BaseException.class);
     }
 
     @Test


### PR DESCRIPTION
## 😇 use-case 배경 설명
<br>
서포터들의 주문에 따라 펀딩에서 main으로 다루어지는 참여자ㅏ수 달성률 펀딩 금액 정보를 담아서 표현한다.

## 🍎 구현한 내용 설명
<br>
주문을 하면 참여자수, 달성률, 달성 금액, 달성 여부 기능이 추가된다. update 형식으로 funding에는 변화가 반영된다.
반대로 주문을 취소하면 등록된 정보들은 모두 반환되고 혹여나 반환 정보에 따른 펀딩 성공 실패 여부도 결정된다.

## 📌리뷰어 리뷰 포인트
<br>

## 📝api 명세 <!--선택-->
<br>
fundingScuccessRate, fundingAmount, fundingSuccess, fundingParticipants 필드 추가,
update메소드, 취소에 따른 rollback 메소드 등을 추가함

## 👩‍💻테스트 <!--선택-->
<br>
